### PR TITLE
Fix: Sanitize DID in output filenames and directories for Windows/NTFS compatibility (#13)

### DIFF
--- a/blob.go
+++ b/blob.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 
 	comatproto "github.com/bluesky-social/indigo/api/atproto"
 	"github.com/bluesky-social/indigo/xrpc"
@@ -92,6 +93,9 @@ func runBlobExport(ctx context.Context, cmd *cli.Command) error {
 
 	topDir := cmd.String("output")
 	if topDir == "" {
+		if strings.Contains(username, ":") {
+			username = strings.ReplaceAll(username, ":", "_")
+		}
 		topDir = fmt.Sprintf("%s_blobs", username)
 	}
 

--- a/repo.go
+++ b/repo.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	comatproto "github.com/bluesky-social/indigo/api/atproto"
@@ -118,11 +119,15 @@ func runRepoExport(ctx context.Context, cmd *cli.Command) error {
 	xrpcc.Client.Timeout = 600 * time.Second
 
 	carPath := cmd.String("output")
-	if carPath == "" {
-		// NOTE: having the rev in the the path might be nice
-		now := time.Now().Format("20060102150405")
-		carPath = fmt.Sprintf("%s.%s.car", username, now)
-	}
+    if carPath == "" {
+
+		if strings.Contains(username, ":") {
+			username = strings.ReplaceAll(username, ":", "_")
+		}
+
+        now := time.Now().Format("20060102150405")
+        carPath = fmt.Sprintf("%s.%s.car", username, now)
+    }
 	output, err := getFileOrStdout(carPath)
 	if err != nil {
 		if errors.Is(err, os.ErrExist) {
@@ -261,9 +266,11 @@ func runRepoUnpack(ctx context.Context, cmd *cli.Command) error {
 		return err
 	}
 
+	sanitizedDID := strings.ReplaceAll(did.String(), ":", "_")
+
 	topDir := cmd.String("output")
 	if topDir == "" {
-		topDir = did.String()
+		topDir = sanitizedDID
 	}
 	fmt.Printf("writing output to: %s\n", topDir)
 


### PR DESCRIPTION
Fixes #13 

Fixes an issue where the `goat repo export`, `goat repo unpack`, and `goat blob export` commands generated file and directory names containing a `:` when using a DID, which is an invalid character in NTFS, causing these commands to fail on Windows.

This change adds sanitization of the DID used in the file output path, replacing colons (`:`) with underscores (`_`).