### PR TITLE
Preserve rotation keys and services during migrate

### DIFF
--- a/account_migrate.go
+++ b/account_migrate.go
@@ -5,7 +5,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
+	"net/http"
+	"slices"
 	"strings"
 	"time"
 
@@ -13,6 +16,7 @@ import (
 	comatproto "github.com/bluesky-social/indigo/api/atproto"
 	"github.com/bluesky-social/indigo/atproto/atclient"
 	"github.com/bluesky-social/indigo/atproto/syntax"
+	"github.com/did-method-plc/go-didplc"
 
 	"github.com/urfave/cli/v3"
 )
@@ -221,20 +225,51 @@ func runAccountMigrate(ctx context.Context, cmd *cli.Command) error {
 	// NOTE: to work with did:web or non-PDS-managed did:plc, need to do manual migraiton process
 	slog.Info("updating identity to new host")
 
-	credsResp, err := agnostic.IdentityGetRecommendedDidCredentials(ctx, newClient)
+	lastOp, err := getLastDidOp(did)
+	if err != nil {
+		return fmt.Errorf("failed fetching last operation: %w", err)
+	}
+	oldRecommended, err := getRecommendedDidCredentials(ctx, oldClient)
+	if err != nil {
+		return fmt.Errorf("failed fetching old credentials: %w", err)
+	}
+	newRecommended, err := getRecommendedDidCredentials(ctx, newClient)
 	if err != nil {
 		return fmt.Errorf("failed fetching new credentials: %w", err)
 	}
-	credsBytes, err := json.Marshal(credsResp)
-	if err != nil {
-		return nil
+
+	rotationKeys := make([]string, 0)
+	for _, rotationKey := range lastOp.RotationKeys {
+		if !slices.Contains(oldRecommended.RotationKeys, rotationKey) {
+			rotationKeys = append(rotationKeys, rotationKey)
+		}
+	}
+	for _, rotationKey := range newRecommended.RotationKeys {
+		rotationKeys = append(rotationKeys, rotationKey)
+	}
+	mergedOp := didplc.RegularOp{
+		AlsoKnownAs: newRecommended.AlsoKnownAs,
+		RotationKeys: rotationKeys,
+		VerificationMethods: newRecommended.VerificationMethods,
+		Services: lastOp.Services,
+	}
+	for opType, _ := range oldRecommended.Services {
+		delete(mergedOp.Services, opType)
+	}
+	for opType, op := range newRecommended.Services {
+		mergedOp.Services[opType] = op
 	}
 
 	var unsignedOp agnostic.IdentitySignPlcOperation_Input
-	if err = json.Unmarshal(credsBytes, &unsignedOp); err != nil {
+	credBytes, err := json.Marshal(mergedOp)
+	if err != nil {
+		return err
+	}
+	if err = json.Unmarshal(credBytes, &unsignedOp); err != nil {
 		return fmt.Errorf("failed parsing PLC op: %w", err)
 	}
 	unsignedOp.Token = &plcToken
+
 
 	// NOTE: could add additional sanity checks here that any extra rotation keys were retained, and that old alsoKnownAs and service entries are retained? The stakes aren't super high for the later, as PLC has the full history. PLC and the new PDS already implement some basic sanity checks.
 
@@ -264,4 +299,55 @@ func runAccountMigrate(ctx context.Context, cmd *cli.Command) error {
 
 	slog.Info("account migration completed")
 	return nil
+}
+
+func getRecommendedDidCredentials(ctx context.Context, client *atclient.APIClient) (didplc.RegularOp, error) {
+	var operation didplc.RegularOp
+	credsResp, err := agnostic.IdentityGetRecommendedDidCredentials(ctx, client)
+	if err != nil {
+		return operation, fmt.Errorf("failed fetching new credentials: %w", err)
+	}
+	credsBytes, err := json.MarshalIndent(credsResp, "", "  ")
+	if err != nil {
+		return operation, err
+	}
+
+	if err = json.Unmarshal(credsBytes, &operation); err != nil {
+		return operation, fmt.Errorf("failed parsing PLC op: %w", err)
+	}
+	return operation, nil
+}
+
+func getLastDidOp(did syntax.DID) (didplc.RegularOp, error) {
+	var lastOp didplc.RegularOp
+	url := fmt.Sprintf("https://plc.directory/%s/log", did)
+	resp, err := http.Get(url)
+	if err != nil {
+		return lastOp, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return lastOp, fmt.Errorf("PLC HTTP request failed")
+	}
+	respBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return lastOp, err
+	}
+
+	// parse JSON and reformat for printing
+	var oplog []map[string]interface{}
+	err = json.Unmarshal(respBytes, &oplog)
+	if err != nil {
+		return lastOp, err
+	}
+
+	lastOpBytes, err := json.Marshal(oplog[len(oplog) - 1])
+	if err != nil {
+		return lastOp, err
+	}
+	if err = json.Unmarshal(lastOpBytes, &lastOp); err != nil {
+		return lastOp, fmt.Errorf("failed parsing PLC op: %w", err)
+	}
+
+	return lastOp, nil
 }


### PR DESCRIPTION
When migrating an account between PDSs the services and rotation keys need to be updated to remove the ability for the old PDS to issue updates and grant it to the new one.

This was previously done by simply setting these to the recommended credentials from the new server. This works for a basic account but can cause problems e.g.

* If there are additional rotation keys such as a recovery key these are lost on PDS migration
* If there are additional services such as a labeller or feed generator these are lost on PDS migration.

This addresses this by instead
1. Start with the last did operation
2. Remove any services or remotes suggested by the old PDS
3. Add any services or rotation keys suggested by the new PDS

Since the PDS "getRecommendedCredentials" only returns it's own keys or services this should still result in a correct DID update without losing additional things that have been added.