### PR TITLE
feat: add key decode command to convert multibase to hex

### DIFF
--- a/key.go
+++ b/key.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/hex"
 	"fmt"
 
 	"github.com/bluesky-social/indigo/atproto/atcrypto"
@@ -34,6 +35,12 @@ var cmdKey = &cli.Command{
 			Usage:     "parses and outputs metadata about a public or secret key",
 			ArgsUsage: `<key>`,
 			Action:    runKeyInspect,
+		},
+		&cli.Command{
+			Name:      "decode",
+			Usage:     "decode multibase key to hex format",
+			ArgsUsage: `<multibase-key>`,
+			Action:    runKeyDecode,
 		},
 	},
 }
@@ -122,4 +129,19 @@ func runKeyInspect(ctx context.Context, cmd *cli.Command) error {
 		return nil
 	}
 	return fmt.Errorf("unknown key encoding or type")
+}
+
+func runKeyDecode(ctx context.Context, cmd *cli.Command) error {
+	multibaseKey := cmd.Args().First()
+	if multibaseKey == "" {
+		return fmt.Errorf("need to provide multibase key as an argument")
+	}
+
+	privKey, err := atcrypto.ParsePrivateMultibase(multibaseKey)
+	if err != nil {
+		return fmt.Errorf("failed to parse multibase key: %w", err)
+	}
+	rawBytes := privKey.Bytes()
+	fmt.Println(hex.EncodeToString(rawBytes))
+	return nil
 }


### PR DESCRIPTION
Adds a new `goat key decode` subcommand that converts multibase-encoded private keys to hexadecimal format. This is useful for integrating with systems like Ozone that require hex-encoded keys.

Implementation leverages the existing atcrypto package from indigo, ensuring consistency with the rest of the codebase and supporting both K-256 and P-256 key types automatically.

Usage:
  goat key decode <multibase-key>

Example:
  $ goat key decode z3vLXuhtKmvWVGNaqPnYs7ePhbNmJX4eqMALAEEqnrftD3uK
  3a1aa74eabfda2034c992575742fa7c54fe93a3e4e0642489f5afc825c0c88b2

🤖 Generated with [Claude Code](https://claude.com/claude-code)