### PR TITLE
check that client != nil in login command

### DIFF
--- a/account.go
+++ b/account.go
@@ -217,6 +217,11 @@ func runAccountLogin(ctx context.Context, cmd *cli.Command) error {
 		return err
 	}
 
+	// defensive check: the above should never return a nil client
+	if client == nil || client.Auth == nil {
+		return fmt.Errorf("login failed")
+	}
+
 	passAuth, ok := client.Auth.(*atclient.PasswordAuth)
 	if !ok {
 		return fmt.Errorf("expected password auth")


### PR DESCRIPTION
This rubs me a the wrong way a bit, because `client` and `client.Auth` should never be `nil` at this point in the code. The ptr assignment code just above isn't great style, but if there is an actual bug I don't see it.

This is in response to an underlying HTTPS proxying bug resulting in an actual panic, as reported in: https://github.com/bluesky-social/goat/issues/22