### PR TITLE
JWK support for key generate and inspect

### DIFF
--- a/key.go
+++ b/key.go
@@ -2,12 +2,26 @@ package main
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/bluesky-social/indigo/atproto/atcrypto"
 
 	"github.com/urfave/cli/v3"
 )
+
+// PrivateJWK extends JWK with the "d" parameter for private key material.
+// This is used for serializing private keys in JWK format.
+type PrivateJWK struct {
+	KeyType string `json:"kty"`
+	Curve   string `json:"crv"`
+	X       string `json:"x"`             // base64url, no padding
+	Y       string `json:"y"`             // base64url, no padding
+	D       string `json:"d"`             // base64url, no padding (private key)
+	Use     string `json:"use,omitempty"`
+}
 
 var cmdKey = &cli.Command{
 	Name:  "key",
@@ -26,6 +40,11 @@ var cmdKey = &cli.Command{
 					Name:  "terse",
 					Usage: "print just the secret key, in multikey format",
 				},
+				&cli.StringFlag{
+					Name:    "output",
+					Aliases: []string{"o"},
+					Usage:   "output format: plain (default) or jwk",
+				},
 			},
 			Action: runKeyGenerate,
 		},
@@ -39,38 +58,76 @@ var cmdKey = &cli.Command{
 }
 
 func runKeyGenerate(ctx context.Context, cmd *cli.Command) error {
-	var priv atcrypto.PrivateKey
-	var privMultibase string
+	var priv atcrypto.PrivateKeyExportable
 	switch cmd.String("type") {
 	case "", "P-256", "p256", "ES256", "secp256r1":
 		sec, err := atcrypto.GeneratePrivateKeyP256()
 		if err != nil {
 			return err
 		}
-		privMultibase = sec.Multibase()
 		priv = sec
 	case "K-256", "k256", "ES256K", "secp256k1":
 		sec, err := atcrypto.GeneratePrivateKeyK256()
 		if err != nil {
 			return err
 		}
-		privMultibase = sec.Multibase()
 		priv = sec
 	default:
 		return fmt.Errorf("unknown key type: %s", cmd.String("type"))
 	}
-	if cmd.Bool("terse") {
-		fmt.Println(privMultibase)
+
+	outputFormat := cmd.String("output")
+	switch outputFormat {
+	case "", "plain":
+		if cmd.Bool("terse") {
+			fmt.Println(priv.Multibase())
+			return nil
+		}
+		pub, err := priv.PublicKey()
+		if err != nil {
+			return err
+		}
+		fmt.Printf("Key Type: %s\n", descKeyType(priv))
+		fmt.Printf("Secret Key (Multibase Syntax): save this securely (eg, add to password manager)\n\t%s\n", priv.Multibase())
+		fmt.Printf("Public Key (DID Key Syntax): share or publish this (eg, in DID document)\n\t%s\n", pub.DIDKey())
 		return nil
+	case "jwk":
+		jwk, err := privateKeyToJWK(priv)
+		if err != nil {
+			return err
+		}
+		out, err := json.MarshalIndent(jwk, "", "  ")
+		if err != nil {
+			return err
+		}
+		fmt.Println(string(out))
+		return nil
+	default:
+		return fmt.Errorf("unknown output format: %s (use 'plain' or 'jwk')", outputFormat)
 	}
+}
+
+// privateKeyToJWK converts a private key to JWK format.
+func privateKeyToJWK(priv atcrypto.PrivateKeyExportable) (*PrivateJWK, error) {
 	pub, err := priv.PublicKey()
 	if err != nil {
-		return err
+		return nil, err
 	}
-	fmt.Printf("Key Type: %s\n", descKeyType(priv))
-	fmt.Printf("Secret Key (Multibase Syntax): save this securely (eg, add to password manager)\n\t%s\n", privMultibase)
-	fmt.Printf("Public Key (DID Key Syntax): share or publish this (eg, in DID document)\n\t%s\n", pub.DIDKey())
-	return nil
+	pubJWK, err := pub.JWK()
+	if err != nil {
+		return nil, err
+	}
+
+	// The private key bytes are the scalar "d" value
+	dBytes := priv.Bytes()
+
+	return &PrivateJWK{
+		KeyType: pubJWK.KeyType,
+		Curve:   pubJWK.Curve,
+		X:       pubJWK.X,
+		Y:       pubJWK.Y,
+		D:       base64.RawURLEncoding.EncodeToString(dBytes),
+	}, nil
 }
 
 func descKeyType(val interface{}) string {
@@ -92,6 +149,11 @@ func runKeyInspect(ctx context.Context, cmd *cli.Command) error {
 	s := cmd.Args().First()
 	if s == "" {
 		return fmt.Errorf("need to provide key as an argument")
+	}
+
+	// Try parsing as JWK (JSON format)
+	if strings.HasPrefix(strings.TrimSpace(s), "{") {
+		return inspectJWK(s)
 	}
 
 	sec, err := atcrypto.ParsePrivateMultibase(s)
@@ -122,4 +184,69 @@ func runKeyInspect(ctx context.Context, cmd *cli.Command) error {
 		return nil
 	}
 	return fmt.Errorf("unknown key encoding or type")
+}
+
+// inspectJWK parses and displays information about a JWK.
+func inspectJWK(s string) error {
+	// First try to parse as a private JWK (with "d" field)
+	var privJWK PrivateJWK
+	if err := json.Unmarshal([]byte(s), &privJWK); err != nil {
+		return fmt.Errorf("invalid JWK JSON: %w", err)
+	}
+
+	if privJWK.KeyType != "EC" {
+		return fmt.Errorf("unsupported JWK key type: %s", privJWK.KeyType)
+	}
+
+	// Check if this is a private key (has "d" field)
+	if privJWK.D != "" {
+		return inspectPrivateJWK(privJWK)
+	}
+
+	// Parse as public key using atcrypto
+	pub, err := atcrypto.ParsePublicJWKBytes([]byte(s))
+	if err != nil {
+		return fmt.Errorf("parsing public JWK: %w", err)
+	}
+
+	fmt.Printf("Type: %s\n", descKeyType(pub))
+	fmt.Printf("Encoding: JWK (public)\n")
+	fmt.Printf("As DID Key: %s\n", pub.DIDKey())
+	fmt.Printf("As Multibase: %s\n", pub.Multibase())
+	return nil
+}
+
+// inspectPrivateJWK parses and displays information about a private JWK.
+func inspectPrivateJWK(jwk PrivateJWK) error {
+	dBytes, err := base64.RawURLEncoding.DecodeString(jwk.D)
+	if err != nil {
+		return fmt.Errorf("invalid JWK 'd' parameter encoding: %w", err)
+	}
+
+	var priv atcrypto.PrivateKeyExportable
+	switch jwk.Curve {
+	case "P-256":
+		priv, err = atcrypto.ParsePrivateBytesP256(dBytes)
+		if err != nil {
+			return fmt.Errorf("invalid P-256 private key: %w", err)
+		}
+	case "secp256k1":
+		priv, err = atcrypto.ParsePrivateBytesK256(dBytes)
+		if err != nil {
+			return fmt.Errorf("invalid K-256 private key: %w", err)
+		}
+	default:
+		return fmt.Errorf("unsupported JWK curve: %s", jwk.Curve)
+	}
+
+	pub, err := priv.PublicKey()
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Type: %s\n", descKeyType(priv))
+	fmt.Printf("Encoding: JWK (private)\n")
+	fmt.Printf("As Multibase: %s\n", priv.Multibase())
+	fmt.Printf("Public (DID Key): %s\n", pub.DIDKey())
+	return nil
 }


### PR DESCRIPTION
This PR introduces support for JSON Web Key (JWK) output and parsing for the `key generate` and `key inspect` commands.

When generating a key, the `--output` argument can be used to use "plain" (current and default) or "jwk" output.

`goat key generate --output jwk`

```bash
$ goat key generate --type=k256 --output=jwk
{
  "kty": "EC",
  "crv": "secp256k1",
  "x": "oLnl07HHx1B_4kVBgbITi42dpaSuadbt-ze70LnpLSk",
  "y": "oIFT-nRC3cSahsiaZdsGD-MQe5UB1u-1YDXt1XCgxmU",
  "d": "bHE8kTOa6HGEm6gG3e26_Yx2p6-wmZimI5qmq4TJmQE"
}
```

When inspecting keys, a JWK string can be provided to inspect:

```bash
$ goat key inspect '{"kty": "EC","crv": "secp256k1","x": "oLnl07HHx1B_4kVBgbITi42dpaSuadbt-ze70LnpLSk","y": "oIFT-nRC3cSahsiaZdsGD-MQe5UB1u-1YDXt1XCgxmU","d": "bHE8kTOa6HGEm6gG3e26_Yx2p6-wmZimI5qmq4TJmQE"}'
Type: K-256 / secp256k1 / ES256K private key
Encoding: JWK (private)
As Multibase: z3vLbJCqy79rpBEFFMXU1CXpSF9ydoTVCJY1Y7iP2R4BEMmr
Public (DID Key): did:key:zQ3shqTWmVNXtmJjDM9zu5cy1Y2afkbw1n9owig6NBQZsG75r
```