### PR TITLE
added plc var to export

### DIFF
--- a/blob.go
+++ b/blob.go
@@ -16,7 +16,14 @@ import (
 var cmdBlob = &cli.Command{
 	Name:  "blob",
 	Usage: "commands for media files (blobs)",
-	Flags: []cli.Flag{},
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:    "plc-host",
+			Usage:   "method, hostname, and port of PLC registry",
+			Value:   "https://plc.directory",
+			Sources: cli.EnvVars("ATP_PLC_HOST"),
+		},
+	},
 	Commands: []*cli.Command{
 		&cli.Command{
 			Name:      "export",
@@ -71,7 +78,8 @@ func runBlobExport(ctx context.Context, cmd *cli.Command) error {
 	if username == "" {
 		return fmt.Errorf("need to provide username as an argument")
 	}
-	ident, err := resolveIdent(ctx, username)
+	plcHost := cmd.String("plc-host")
+	ident, err := resolveIdentWithPLC(ctx, username, plcHost)
 	if err != nil {
 		return err
 	}
@@ -132,7 +140,8 @@ func runBlobList(ctx context.Context, cmd *cli.Command) error {
 	if username == "" {
 		return fmt.Errorf("need to provide username as an argument")
 	}
-	ident, err := resolveIdent(ctx, username)
+	plcHost := cmd.String("plc-host")
+	ident, err := resolveIdentWithPLC(ctx, username, plcHost)
 	if err != nil {
 		return err
 	}
@@ -168,7 +177,8 @@ func runBlobDownload(ctx context.Context, cmd *cli.Command) error {
 		return fmt.Errorf("need to provide blob CID as second argument")
 	}
 	blobCID := cmd.Args().Get(1)
-	ident, err := resolveIdent(ctx, username)
+	plcHost := cmd.String("plc-host")
+	ident, err := resolveIdentWithPLC(ctx, username, plcHost)
 	if err != nil {
 		return err
 	}

--- a/repo.go
+++ b/repo.go
@@ -24,7 +24,14 @@ import (
 var cmdRepo = &cli.Command{
 	Name:  "repo",
 	Usage: "commands for public atproto data repositories",
-	Flags: []cli.Flag{},
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:    "plc-host",
+			Usage:   "method, hostname, and port of PLC registry",
+			Value:   "https://plc.directory",
+			Sources: cli.EnvVars("ATP_PLC_HOST"),
+		},
+	},
 	Commands: []*cli.Command{
 		&cli.Command{
 			Name:      "export",
@@ -99,7 +106,8 @@ func runRepoExport(ctx context.Context, cmd *cli.Command) error {
 	if username == "" {
 		return fmt.Errorf("need to provide username as an argument")
 	}
-	ident, err := resolveIdent(ctx, username)
+	plcHost := cmd.String("plc-host")
+	ident, err := resolveIdentWithPLC(ctx, username, plcHost)
 	if err != nil {
 		return err
 	}

--- a/util.go
+++ b/util.go
@@ -16,12 +16,23 @@ import (
 )
 
 func resolveIdent(ctx context.Context, arg string) (*identity.Identity, error) {
+	return resolveIdentWithPLC(ctx, arg, "")
+}
+
+func resolveIdentWithPLC(ctx context.Context, arg string, plcHost string) (*identity.Identity, error) {
 	id, err := syntax.ParseAtIdentifier(arg)
 	if err != nil {
 		return nil, err
 	}
 
-	dir := identity.DefaultDirectory()
+	var dir identity.Directory
+	if plcHost != "" {
+		dir = &identity.BaseDirectory{
+			PLCURL: plcHost,
+		}
+	} else {
+		dir = identity.DefaultDirectory()
+	}
 	return dir.Lookup(ctx, id)
 }
 


### PR DESCRIPTION
Add support for `ATP_PLC_HOST` environment variable to `repo` and `blob` commands for DID resolution against custom PLC directories.

# Problem
The `goat repo export` and `goat blob export` commands were hardcoded to use the default PLC directory (plc.directory) for DID resolution, even when the `ATP_PLC_HOST` environment variable was set. This prevented these commands from working with custom PLC directories, while other commands like goat plc history already respected this configuration.

# Changes
Added command line var to `util.go`, `repo.go` and `blob.go`

# Usage
Users can now specify a custom PLC directory in two ways:
```
# Environment variable
export ATP_PLC_HOST=https://custom.plc.example.com
goat repo export username.bsky.social

# Command-line flag
goat repo --plc-host https://custom.plc.example.com export username.bsky.social
goat blob --plc-host https://custom.plc.example.com export username.bsky.social
```
