### PR TITLE
configurable PLC directory throughout all commands

### DIFF
--- a/account.go
+++ b/account.go
@@ -11,7 +11,6 @@ import (
 	"github.com/bluesky-social/indigo/atproto/atclient"
 	"github.com/bluesky-social/indigo/atproto/atcrypto"
 	"github.com/bluesky-social/indigo/atproto/auth"
-	"github.com/bluesky-social/indigo/atproto/identity"
 	"github.com/bluesky-social/indigo/atproto/syntax"
 
 	"github.com/urfave/cli/v3"
@@ -211,7 +210,7 @@ func runAccountLogin(ctx context.Context, cmd *cli.Command) error {
 		if err != nil {
 			return err
 		}
-		dir := identity.DefaultDirectory()
+		dir := configDirectory(cmd.String("plc-host"))
 		client, err = atclient.LoginWithPassword(ctx, dir, username, cmd.String("app-password"), cmd.String("auth-factor-token"), authRefreshCallback)
 	}
 	if err != nil {
@@ -242,7 +241,7 @@ func runAccountStatus(ctx context.Context, cmd *cli.Command) error {
 	if username == "" {
 		return fmt.Errorf("need to provide username as an argument")
 	}
-	ident, err := resolveIdent(ctx, username)
+	ident, err := resolveIdent(ctx, cmd, username)
 	if err != nil {
 		return err
 	}
@@ -272,7 +271,7 @@ func runAccountStatus(ctx context.Context, cmd *cli.Command) error {
 
 func runAccountCheckAuth(ctx context.Context, cmd *cli.Command) error {
 
-	client, err := loadAuthClient(ctx)
+	client, err := loadAuthClient(ctx, cmd)
 	if err == ErrNoAuthSession {
 		return fmt.Errorf("auth required, but not logged in")
 	} else if err != nil {
@@ -297,7 +296,7 @@ func runAccountCheckAuth(ctx context.Context, cmd *cli.Command) error {
 
 func runAccountMissingBlobs(ctx context.Context, cmd *cli.Command) error {
 
-	client, err := loadAuthClient(ctx)
+	client, err := loadAuthClient(ctx, cmd)
 	if err == ErrNoAuthSession {
 		return fmt.Errorf("auth required, but not logged in")
 	} else if err != nil {
@@ -324,7 +323,7 @@ func runAccountMissingBlobs(ctx context.Context, cmd *cli.Command) error {
 
 func runAccountActivate(ctx context.Context, cmd *cli.Command) error {
 
-	client, err := loadAuthClient(ctx)
+	client, err := loadAuthClient(ctx, cmd)
 	if err == ErrNoAuthSession {
 		return fmt.Errorf("auth required, but not logged in")
 	} else if err != nil {
@@ -341,7 +340,7 @@ func runAccountActivate(ctx context.Context, cmd *cli.Command) error {
 
 func runAccountDeactivate(ctx context.Context, cmd *cli.Command) error {
 
-	client, err := loadAuthClient(ctx)
+	client, err := loadAuthClient(ctx, cmd)
 	if err == ErrNoAuthSession {
 		return fmt.Errorf("auth required, but not logged in")
 	} else if err != nil {
@@ -367,7 +366,7 @@ func runAccountUpdateHandle(ctx context.Context, cmd *cli.Command) error {
 		return err
 	}
 
-	client, err := loadAuthClient(ctx)
+	client, err := loadAuthClient(ctx, cmd)
 	if err == ErrNoAuthSession {
 		return fmt.Errorf("auth required, but not logged in")
 	} else if err != nil {
@@ -386,7 +385,7 @@ func runAccountUpdateHandle(ctx context.Context, cmd *cli.Command) error {
 
 func runAccountServiceAuth(ctx context.Context, cmd *cli.Command) error {
 
-	client, err := loadAuthClient(ctx)
+	client, err := loadAuthClient(ctx, cmd)
 	if err == ErrNoAuthSession {
 		return fmt.Errorf("auth required, but not logged in")
 	} else if err != nil {

--- a/account_migrate.go
+++ b/account_migrate.go
@@ -59,7 +59,7 @@ var cmdAccountMigrate = &cli.Command{
 
 func runAccountMigrate(ctx context.Context, cmd *cli.Command) error {
 	// NOTE: this could check rev / commit before and after and ensure last-minute content additions get lost
-	oldClient, err := loadAuthClient(ctx)
+	oldClient, err := loadAuthClient(ctx, cmd)
 	if err == ErrNoAuthSession {
 		return fmt.Errorf("auth required, but not logged in")
 	} else if err != nil {

--- a/account_plc.go
+++ b/account_plc.go
@@ -21,7 +21,7 @@ var cmdAccountPlc = &cli.Command{
 	Flags: []cli.Flag{
 		&cli.StringFlag{
 			Name:    "plc-host",
-			Usage:   "method, hostname, and port of PLC registry",
+			Usage:   "method, hostname, and port of PLC directory",
 			Value:   "https://plc.directory",
 			Sources: cli.EnvVars("ATP_PLC_HOST"),
 		},
@@ -81,7 +81,7 @@ var cmdAccountPlc = &cli.Command{
 
 func runAccountPlcRecommended(ctx context.Context, cmd *cli.Command) error {
 
-	client, err := loadAuthClient(ctx)
+	client, err := loadAuthClient(ctx, cmd)
 	if err == ErrNoAuthSession {
 		return fmt.Errorf("auth required, but not logged in")
 	} else if err != nil {
@@ -104,7 +104,7 @@ func runAccountPlcRecommended(ctx context.Context, cmd *cli.Command) error {
 
 func runAccountPlcRequestToken(ctx context.Context, cmd *cli.Command) error {
 
-	client, err := loadAuthClient(ctx)
+	client, err := loadAuthClient(ctx, cmd)
 	if err == ErrNoAuthSession {
 		return fmt.Errorf("auth required, but not logged in")
 	} else if err != nil {
@@ -127,7 +127,7 @@ func runAccountPlcSign(ctx context.Context, cmd *cli.Command) error {
 		return fmt.Errorf("need to provide JSON file path as an argument")
 	}
 
-	client, err := loadAuthClient(ctx)
+	client, err := loadAuthClient(ctx, cmd)
 	if err == ErrNoAuthSession {
 		return fmt.Errorf("auth required, but not logged in")
 	} else if err != nil {
@@ -170,7 +170,7 @@ func runAccountPlcSubmit(ctx context.Context, cmd *cli.Command) error {
 		return fmt.Errorf("need to provide JSON file path as an argument")
 	}
 
-	client, err := loadAuthClient(ctx)
+	client, err := loadAuthClient(ctx, cmd)
 	if err == ErrNoAuthSession {
 		return fmt.Errorf("auth required, but not logged in")
 	} else if err != nil {
@@ -215,7 +215,7 @@ func runAccountPlcSubmit(ctx context.Context, cmd *cli.Command) error {
 
 func runAccountPlcCurrent(ctx context.Context, cmd *cli.Command) error {
 
-	client, err := loadAuthClient(ctx)
+	client, err := loadAuthClient(ctx, cmd)
 	if err == ErrNoAuthSession || client.Auth == nil {
 		return fmt.Errorf("auth required, but not logged in")
 	} else if err != nil {
@@ -248,7 +248,7 @@ func runAccountPlcAddRotationKey(ctx context.Context, cmd *cli.Command) error {
 		return err
 	}
 
-	client, err := loadAuthClient(ctx)
+	client, err := loadAuthClient(ctx, cmd)
 	if err == ErrNoAuthSession {
 		return fmt.Errorf("auth required, but not logged in")
 	} else if err != nil {

--- a/auth.go
+++ b/auth.go
@@ -10,7 +10,6 @@ import (
 
 	comatproto "github.com/bluesky-social/indigo/api/atproto"
 	"github.com/bluesky-social/indigo/atproto/atclient"
-	"github.com/bluesky-social/indigo/atproto/identity"
 	"github.com/bluesky-social/indigo/atproto/syntax"
 
 	"github.com/adrg/xdg"
@@ -90,7 +89,7 @@ func loginOrLoadAuthClient(ctx context.Context, cmd *cli.Command) (*atclient.API
 	username := cmd.String("username")
 	password := cmd.String("password")
 	if username != "" && password != "" {
-		dir := identity.DefaultDirectory()
+		dir := configDirectory(cmd.String("plc-host"))
 		atid, err := syntax.ParseAtIdentifier(username)
 		if err != nil {
 			return nil, err
@@ -99,10 +98,10 @@ func loginOrLoadAuthClient(ctx context.Context, cmd *cli.Command) (*atclient.API
 	}
 
 	// otherwise try loading from disk
-	return loadAuthClient(ctx)
+	return loadAuthClient(ctx, cmd)
 }
 
-func loadAuthClient(ctx context.Context) (*atclient.APIClient, error) {
+func loadAuthClient(ctx context.Context, cmd *cli.Command) (*atclient.APIClient, error) {
 
 	sess, err := loadAuthSessionFile()
 	if err != nil {
@@ -124,7 +123,7 @@ func loadAuthClient(ctx context.Context) (*atclient.APIClient, error) {
 	}
 
 	// otherwise try new auth session using saved password
-	dir := identity.DefaultDirectory()
+	dir := configDirectory(cmd.String("plc-host"))
 	return atclient.LoginWithPassword(ctx, dir, sess.DID.AtIdentifier(), sess.Password, "", authRefreshCallback)
 }
 

--- a/blob.go
+++ b/blob.go
@@ -71,7 +71,7 @@ func runBlobExport(ctx context.Context, cmd *cli.Command) error {
 	if username == "" {
 		return fmt.Errorf("need to provide username as an argument")
 	}
-	ident, err := resolveIdent(ctx, username)
+	ident, err := resolveIdent(ctx, cmd, username)
 	if err != nil {
 		return err
 	}
@@ -132,7 +132,7 @@ func runBlobList(ctx context.Context, cmd *cli.Command) error {
 	if username == "" {
 		return fmt.Errorf("need to provide username as an argument")
 	}
-	ident, err := resolveIdent(ctx, username)
+	ident, err := resolveIdent(ctx, cmd, username)
 	if err != nil {
 		return err
 	}
@@ -168,7 +168,7 @@ func runBlobDownload(ctx context.Context, cmd *cli.Command) error {
 		return fmt.Errorf("need to provide blob CID as second argument")
 	}
 	blobCID := cmd.Args().Get(1)
-	ident, err := resolveIdent(ctx, username)
+	ident, err := resolveIdent(ctx, cmd, username)
 	if err != nil {
 		return err
 	}
@@ -200,7 +200,7 @@ func runBlobUpload(ctx context.Context, cmd *cli.Command) error {
 		return fmt.Errorf("need to provide file path as an argument")
 	}
 
-	client, err := loadAuthClient(ctx)
+	client, err := loadAuthClient(ctx, cmd)
 	if err == ErrNoAuthSession {
 		return fmt.Errorf("auth required, but not logged in")
 	} else if err != nil {

--- a/bsky.go
+++ b/bsky.go
@@ -33,7 +33,7 @@ func runBskyPost(ctx context.Context, cmd *cli.Command) error {
 		return fmt.Errorf("need to provide post text as argument")
 	}
 
-	client, err := loadAuthClient(ctx)
+	client, err := loadAuthClient(ctx, cmd)
 	if err == ErrNoAuthSession {
 		return fmt.Errorf("auth required, but not logged in")
 	} else if err != nil {

--- a/bsky_prefs.go
+++ b/bsky_prefs.go
@@ -32,7 +32,7 @@ var cmdBskyPrefs = &cli.Command{
 
 func runBskyPrefsExport(ctx context.Context, cmd *cli.Command) error {
 
-	client, err := loadAuthClient(ctx)
+	client, err := loadAuthClient(ctx, cmd)
 	if err == ErrNoAuthSession {
 		return fmt.Errorf("auth required, but not logged in")
 	} else if err != nil {
@@ -60,7 +60,7 @@ func runBskyPrefsImport(ctx context.Context, cmd *cli.Command) error {
 		return fmt.Errorf("need to provide file path as an argument")
 	}
 
-	client, err := loadAuthClient(ctx)
+	client, err := loadAuthClient(ctx, cmd)
 	if err == ErrNoAuthSession {
 		return fmt.Errorf("auth required, but not logged in")
 	} else if err != nil {

--- a/firehose.go
+++ b/firehose.go
@@ -99,6 +99,7 @@ func runFirehose(ctx context.Context, cmd *cli.Command) error {
 
 	// main thing is skipping handle verification
 	bdir := identity.BaseDirectory{
+		PLCURL:                 cmd.String("plc-host"),
 		SkipHandleVerification: true,
 		TryAuthoritativeDNS:    false,
 		SkipDNSDomainSuffixes:  []string{".bsky.social"},

--- a/identity.go
+++ b/identity.go
@@ -35,7 +35,10 @@ func runResolve(ctx context.Context, cmd *cli.Command) error {
 	if err != nil {
 		return err
 	}
-	dir := identity.BaseDirectory{}
+	bdir := identity.BaseDirectory{
+		PLCURL:    cmd.String("plc-host"),
+		UserAgent: userAgentString(),
+	}
 	var raw json.RawMessage
 
 	if atid.IsDID() {
@@ -47,7 +50,7 @@ func runResolve(ctx context.Context, cmd *cli.Command) error {
 			fmt.Println(did)
 			return nil
 		}
-		raw, err = dir.ResolveDIDRaw(ctx, did)
+		raw, err = bdir.ResolveDIDRaw(ctx, did)
 		if err != nil {
 			return err
 		}
@@ -56,7 +59,7 @@ func runResolve(ctx context.Context, cmd *cli.Command) error {
 		if err != nil {
 			return err
 		}
-		did, err := dir.ResolveHandle(ctx, handle)
+		did, err := bdir.ResolveHandle(ctx, handle)
 		if err != nil {
 			return err
 		}
@@ -64,7 +67,7 @@ func runResolve(ctx context.Context, cmd *cli.Command) error {
 			fmt.Println(did)
 			return nil
 		}
-		raw, err = dir.ResolveDIDRaw(ctx, did)
+		raw, err = bdir.ResolveDIDRaw(ctx, did)
 		if err != nil {
 			return err
 		}

--- a/lex.go
+++ b/lex.go
@@ -132,7 +132,10 @@ func runLexResolve(ctx context.Context, cmd *cli.Command) error {
 		return err
 	}
 
-	dir := identity.BaseDirectory{}
+	dir := identity.BaseDirectory{
+		PLCURL:    cmd.String("plc-host"),
+		UserAgent: userAgentString(),
+	}
 	if cmd.Bool("did") {
 		did, err := dir.ResolveNSID(ctx, nsid)
 		if err != nil {
@@ -169,7 +172,10 @@ func runLexList(ctx context.Context, cmd *cli.Command) error {
 	}
 	authority := nsid.Authority()
 
-	dir := identity.BaseDirectory{}
+	dir := identity.BaseDirectory{
+		PLCURL:    cmd.String("plc-host"),
+		UserAgent: userAgentString(),
+	}
 	did, err := dir.ResolveNSID(ctx, nsid)
 	if err != nil {
 		return err
@@ -227,7 +233,10 @@ func runLexValidate(ctx context.Context, cmd *cli.Command) error {
 
 	var nsid syntax.NSID
 	var recordData map[string]any
-	dir := identity.BaseDirectory{}
+	dir := identity.BaseDirectory{
+		PLCURL:    cmd.String("plc-host"),
+		UserAgent: userAgentString(),
+	}
 	cat := lexicon.NewResolvingCatalog()
 
 	var flags lexicon.ValidateFlags = 0

--- a/lex_check_dns.go
+++ b/lex_check_dns.go
@@ -51,7 +51,10 @@ func runLexCheckDNS(ctx context.Context, cmd *cli.Command) error {
 		localGroups[g] = true
 	}
 
-	dir := identity.BaseDirectory{}
+	dir := identity.BaseDirectory{
+		PLCURL:    cmd.String("plc-host"),
+		UserAgent: userAgentString(),
+	}
 	missingGroups := []string{}
 	for g := range localGroups {
 		_, err := dir.ResolveNSID(ctx, syntax.NSID(g+"name"))

--- a/lex_publish.go
+++ b/lex_publish.go
@@ -92,7 +92,10 @@ func runLexPublish(ctx context.Context, cmd *cli.Command) error {
 		}
 	}
 
-	dir := identity.BaseDirectory{}
+	dir := identity.BaseDirectory{
+		PLCURL:    cmd.String("plc-host"),
+		UserAgent: userAgentString(),
+	}
 	groupResolution := map[string]syntax.DID{}
 	for g := range localGroups {
 		did, err := dir.ResolveNSID(ctx, syntax.NSID(g+"name"))

--- a/lex_pull.go
+++ b/lex_pull.go
@@ -85,7 +85,10 @@ func pullLexicon(ctx context.Context, cmd *cli.Command, nsid syntax.NSID) error 
 
 	// TODO: common net client
 	netc := netclient.NewNetClient()
-	dir := identity.BaseDirectory{}
+	dir := identity.BaseDirectory{
+		PLCURL:    cmd.String("plc-host"),
+		UserAgent: userAgentString(),
+	}
 	did, err := dir.ResolveNSID(ctx, nsid)
 	if err != nil {
 		return fmt.Errorf("failed to resolve NSID %s: %w", nsid, err)

--- a/lex_util.go
+++ b/lex_util.go
@@ -98,7 +98,10 @@ func resolveLexiconGroup(ctx context.Context, cmd *cli.Command, group string, re
 	slog.Debug("resolving schemas for NSID group", "group", group)
 
 	// TODO: netclient support for listing records
-	dir := identity.BaseDirectory{}
+	dir := identity.BaseDirectory{
+		PLCURL:    cmd.String("plc-host"),
+		UserAgent: userAgentString(),
+	}
 	did, err := dir.ResolveNSID(ctx, syntax.NSID(group+"name"))
 	if err != nil {
 		// if NSID isn't registered, just skip comparison

--- a/main.go
+++ b/main.go
@@ -38,6 +38,12 @@ func run(args []string) error {
 				Usage:   "log verbosity level (eg: warn, info, debug)",
 				Sources: cli.EnvVars("GOAT_LOG_LEVEL", "GO_LOG_LEVEL", "LOG_LEVEL"),
 			},
+			&cli.StringFlag{
+				Name:    "plc-host",
+				Usage:   "method, hostname, and port of PLC directory",
+				Value:   "https://plc.directory",
+				Sources: cli.EnvVars("ATP_PLC_HOST"),
+			},
 		},
 	}
 	app.Commands = []*cli.Command{

--- a/pds_admin.go
+++ b/pds_admin.go
@@ -168,7 +168,7 @@ func runPDSAdminAccountTakedown(ctx context.Context, cmd *cli.Command) error {
 	if username == "" {
 		return fmt.Errorf("need to provide username as an argument")
 	}
-	did, err := resolveToDID(ctx, username)
+	did, err := resolveToDID(ctx, cmd, username)
 	if err != nil {
 		return err
 	}
@@ -243,7 +243,7 @@ func runPDSAdminAccountDelete(ctx context.Context, cmd *cli.Command) error {
 	if username == "" {
 		return fmt.Errorf("need to provide username as an argument")
 	}
-	did, err := resolveToDID(ctx, username)
+	did, err := resolveToDID(ctx, cmd, username)
 	if err != nil {
 		return err
 	}
@@ -264,7 +264,7 @@ func runPDSAdminAccountInfo(ctx context.Context, cmd *cli.Command) error {
 	if username == "" {
 		return fmt.Errorf("need to provide username as an argument")
 	}
-	did, err := resolveToDID(ctx, username)
+	did, err := resolveToDID(ctx, cmd, username)
 	if err != nil {
 		return err
 	}
@@ -292,7 +292,7 @@ func runPDSAdminAccountUpdate(ctx context.Context, cmd *cli.Command) error {
 	if username == "" {
 		return fmt.Errorf("need to provide username as an argument")
 	}
-	did, err := resolveToDID(ctx, username)
+	did, err := resolveToDID(ctx, cmd, username)
 	if err != nil {
 		return err
 	}
@@ -340,7 +340,7 @@ func runPDSAdminAccountResetPassword(ctx context.Context, cmd *cli.Command) erro
 	if username == "" {
 		return fmt.Errorf("need to provide username as an argument")
 	}
-	did, err := resolveToDID(ctx, username)
+	did, err := resolveToDID(ctx, cmd, username)
 	if err != nil {
 		return err
 	}
@@ -374,7 +374,7 @@ func runPDSAdminBlobStatus(ctx context.Context, cmd *cli.Command) error {
 		return fmt.Errorf("need to provide blob CID as second argument")
 	}
 
-	did, err := resolveToDID(ctx, username)
+	did, err := resolveToDID(ctx, cmd, username)
 	if err != nil {
 		return err
 	}
@@ -407,7 +407,7 @@ func runPDSAdminBlobPurge(ctx context.Context, cmd *cli.Command) error {
 		return fmt.Errorf("need to provide blob CID as second argument")
 	}
 
-	did, err := resolveToDID(ctx, username)
+	did, err := resolveToDID(ctx, cmd, username)
 	if err != nil {
 		return err
 	}

--- a/plc.go
+++ b/plc.go
@@ -26,7 +26,7 @@ var cmdPLC = &cli.Command{
 	Flags: []cli.Flag{
 		&cli.StringFlag{
 			Name:    "plc-host",
-			Usage:   "method, hostname, and port of PLC registry",
+			Usage:   "method, hostname, and port of PLC directory",
 			Value:   "https://plc.directory",
 			Sources: cli.EnvVars("ATP_PLC_HOST"),
 		},
@@ -177,7 +177,8 @@ func runPLCHistory(ctx context.Context, cmd *cli.Command) error {
 	}
 
 	dir := identity.BaseDirectory{
-		PLCURL: plcHost,
+		PLCURL:    plcHost,
+		UserAgent: userAgentString(),
 	}
 
 	id, err := syntax.ParseAtIdentifier(s)
@@ -245,7 +246,8 @@ func runPLCData(ctx context.Context, cmd *cli.Command) error {
 	}
 
 	dir := identity.BaseDirectory{
-		PLCURL: plcHost,
+		PLCURL:    plcHost,
+		UserAgent: userAgentString(),
 	}
 
 	id, err := syntax.ParseAtIdentifier(s)

--- a/record.go
+++ b/record.go
@@ -11,7 +11,6 @@ import (
 	comatproto "github.com/bluesky-social/indigo/api/atproto"
 	"github.com/bluesky-social/indigo/atproto/atclient"
 	"github.com/bluesky-social/indigo/atproto/atdata"
-	"github.com/bluesky-social/indigo/atproto/identity"
 	"github.com/bluesky-social/indigo/atproto/syntax"
 
 	"github.com/urfave/cli/v3"
@@ -111,7 +110,7 @@ var cmdRecordList = &cli.Command{
 }
 
 func runRecordGet(ctx context.Context, cmd *cli.Command) error {
-	dir := identity.DefaultDirectory()
+	dir := configDirectory(cmd.String("plc-host"))
 
 	uriArg := cmd.Args().First()
 	if uriArg == "" {
@@ -146,7 +145,7 @@ func runRecordList(ctx context.Context, cmd *cli.Command) error {
 	if username == "" {
 		return fmt.Errorf("need to provide username as an argument")
 	}
-	ident, err := resolveIdent(ctx, username)
+	ident, err := resolveIdent(ctx, cmd, username)
 	if err != nil {
 		return err
 	}
@@ -206,7 +205,7 @@ func runRecordCreate(ctx context.Context, cmd *cli.Command) error {
 		return fmt.Errorf("need to provide file path or '-' for stdin as an argument")
 	}
 
-	client, err := loadAuthClient(ctx)
+	client, err := loadAuthClient(ctx, cmd)
 	if err == ErrNoAuthSession {
 		return fmt.Errorf("auth required, but not logged in")
 	} else if err != nil {
@@ -265,7 +264,7 @@ func runRecordUpdate(ctx context.Context, cmd *cli.Command) error {
 		return fmt.Errorf("need to provide file path as an argument")
 	}
 
-	client, err := loadAuthClient(ctx)
+	client, err := loadAuthClient(ctx, cmd)
 	if err == ErrNoAuthSession {
 		return fmt.Errorf("auth required, but not logged in")
 	} else if err != nil {
@@ -315,7 +314,7 @@ func runRecordUpdate(ctx context.Context, cmd *cli.Command) error {
 
 func runRecordDelete(ctx context.Context, cmd *cli.Command) error {
 
-	client, err := loadAuthClient(ctx)
+	client, err := loadAuthClient(ctx, cmd)
 	if err == ErrNoAuthSession {
 		return fmt.Errorf("auth required, but not logged in")
 	} else if err != nil {

--- a/relay_admin.go
+++ b/relay_admin.go
@@ -218,7 +218,7 @@ func runRelayAdminAccountTakedown(ctx context.Context, cmd *cli.Command) error {
 	if username == "" {
 		return fmt.Errorf("need to provide username as an argument")
 	}
-	ident, err := resolveIdent(ctx, username)
+	ident, err := resolveIdent(ctx, cmd, username)
 	if err != nil {
 		return err
 	}

--- a/repo.go
+++ b/repo.go
@@ -99,7 +99,7 @@ func runRepoExport(ctx context.Context, cmd *cli.Command) error {
 	if username == "" {
 		return fmt.Errorf("need to provide username as an argument")
 	}
-	ident, err := resolveIdent(ctx, username)
+	ident, err := resolveIdent(ctx, cmd, username)
 	if err != nil {
 		return err
 	}
@@ -149,7 +149,7 @@ func runRepoImport(ctx context.Context, cmd *cli.Command) error {
 		return fmt.Errorf("need to provide CAR file path as an argument")
 	}
 
-	client, err := loadAuthClient(ctx)
+	client, err := loadAuthClient(ctx, cmd)
 	if err == ErrNoAuthSession {
 		return fmt.Errorf("auth required, but not logged in")
 	} else if err != nil {


### PR DESCRIPTION
This copies the 'plc-host' flag to the top-level command, and updates all resolution to use the configured directory. This makes it possible to configure via environment variable (eg, for local/alternative development) and get consistent results.