### PR TITLE
Allow creating accounts from goat admin

### DIFF
--- a/account.go
+++ b/account.go
@@ -160,21 +160,23 @@ var cmdAccount = &cli.Command{
 					Name:     "handle",
 					Usage:    "handle for new account",
 					Required: true,
-					Sources:  cli.EnvVars("ATP_AUTH_HANDLE"),
+					Sources:  cli.EnvVars("NEW_ACCOUNT_HANDLE"),
 				},
 				&cli.StringFlag{
 					Name:     "password",
 					Usage:    "initial account password",
 					Required: true,
-					Sources:  cli.EnvVars("ATP_AUTH_PASSWORD"),
+					Sources:  cli.EnvVars("NEW_ACCOUNT_PASSWORD"),
+				},
+				&cli.StringFlag{
+					Name:     "email",
+					Usage:    "email address for new account",
+					Required: true,
+					Sources:  cli.EnvVars("NEW_ACCOUNT_EMAIL"),
 				},
 				&cli.StringFlag{
 					Name:  "invite-code",
 					Usage: "invite code for account signup",
-				},
-				&cli.StringFlag{
-					Name:  "email",
-					Usage: "email address for new account",
 				},
 				&cli.StringFlag{
 					Name:  "existing-did",

--- a/pds_admin.go
+++ b/pds_admin.go
@@ -98,17 +98,19 @@ var cmdPDSAdmin = &cli.Command{
 							Name:     "handle",
 							Usage:    "handle for new account",
 							Required: true,
-							Sources:  cli.EnvVars("ATP_AUTH_HANDLE"),
+							Sources:  cli.EnvVars("NEW_ACCOUNT_HANDLE"),
 						},
 						&cli.StringFlag{
 							Name:     "password",
 							Usage:    "initial account password",
 							Required: true,
-							Sources:  cli.EnvVars("ATP_AUTH_PASSWORD"),
+							Sources:  cli.EnvVars("NEW_ACCOUNT_PASSWORD"),
 						},
 						&cli.StringFlag{
-							Name:  "email",
-							Usage: "email address for new account",
+							Name:     "email",
+							Required: true,
+							Usage:    "email address for new account",
+							Sources:  cli.EnvVars("NEW_ACCOUNT_EMAIL"),
 						},
 						&cli.StringFlag{
 							Name:  "existing-did",


### PR DESCRIPTION
Prior to this, to replace the one-line `pdsadmin account create` you would have had to run two different commands:

```
goat pds admin --pds-host https://justdothings.net/ --admin-password my-password create-invites

goat account create --pds-host https://justdothings.net/ --handle testuser.justdothings.net --email new-user@email.com --password test-password --invite-code invite-code-from-last-step
```

This makes it possible to do:

```
goat pds admin account create --pds-host https://justdothings.net --admin-password my-password --handle testuser.justdothings.net --email new-user@email.com --password test-password
```

Bypassing the need to create invite codes as an admin.