### PR TITLE
feat: colorize JSON outputs from commands

### DIFF
--- a/account.go
+++ b/account.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -285,13 +284,11 @@ func runAccountCheckAuth(ctx context.Context, cmd *cli.Command) error {
 		return fmt.Errorf("failed checking account status: %w", err)
 	}
 
-	b, err := json.MarshalIndent(status, "", "  ")
-	if err != nil {
-		return err
-	}
 	fmt.Printf("DID: %s\n", client.AccountDID)
 	fmt.Printf("Host: %s\n", client.Host)
-	fmt.Println(string(b))
+	if err := printJSON(status, colorEnabled(cmd)); err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/account_plc.go
+++ b/account_plc.go
@@ -93,13 +93,7 @@ func runAccountPlcRecommended(ctx context.Context, cmd *cli.Command) error {
 		return err
 	}
 
-	b, err := json.MarshalIndent(resp, "", "  ")
-	if err != nil {
-		return err
-	}
-
-	fmt.Println(string(b))
-	return nil
+	return printJSON(resp, colorEnabled(cmd))
 }
 
 func runAccountPlcRequestToken(ctx context.Context, cmd *cli.Command) error {
@@ -154,13 +148,7 @@ func runAccountPlcSign(ctx context.Context, cmd *cli.Command) error {
 		return err
 	}
 
-	b, err := json.MarshalIndent(resp.Operation, "", "  ")
-	if err != nil {
-		return err
-	}
-
-	fmt.Println(string(b))
-	return nil
+	return printJSON(resp.Operation, colorEnabled(cmd))
 }
 
 func runAccountPlcSubmit(ctx context.Context, cmd *cli.Command) error {
@@ -227,12 +215,7 @@ func runAccountPlcCurrent(ctx context.Context, cmd *cli.Command) error {
 		return err
 	}
 
-	b, err := json.MarshalIndent(plcData, "", "  ")
-	if err != nil {
-		return err
-	}
-	fmt.Println(string(b))
-	return nil
+	return printJSON(plcData, colorEnabled(cmd))
 }
 
 func runAccountPlcAddRotationKey(ctx context.Context, cmd *cli.Command) error {

--- a/blob.go
+++ b/blob.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"os"
 
@@ -226,11 +225,9 @@ func runBlobUpload(ctx context.Context, cmd *cli.Command) error {
 		return err
 	}
 
-	b, err := json.MarshalIndent(resp.Blob, "", "  ")
-	if err != nil {
+	if err := printJSON(resp.Blob, colorEnabled(cmd)); err != nil {
 		return err
 	}
 
-	fmt.Println(string(b))
 	return nil
 }

--- a/bsky_prefs.go
+++ b/bsky_prefs.go
@@ -45,11 +45,9 @@ func runBskyPrefsExport(ctx context.Context, cmd *cli.Command) error {
 		return fmt.Errorf("failed fetching old preferences: %w", err)
 	}
 
-	b, err := json.MarshalIndent(resp.Preferences, "", "  ")
-	if err != nil {
+	if err := printJSON(resp.Preferences, colorEnabled(cmd)); err != nil {
 		return err
 	}
-	fmt.Println(string(b))
 
 	return nil
 }

--- a/firehose.go
+++ b/firehose.go
@@ -23,6 +23,7 @@ import (
 	lexutil "github.com/bluesky-social/indigo/lex/util"
 
 	"github.com/gorilla/websocket"
+	"github.com/tidwall/pretty"
 	"github.com/urfave/cli/v3"
 )
 
@@ -84,6 +85,7 @@ type GoatFirehoseConsumer struct {
 	AccountsOnly bool
 	Quiet        bool
 	Blocks       bool
+	Color        bool
 	VerifyBasic  bool
 	VerifySig    bool
 	VerifyMST    bool
@@ -113,6 +115,7 @@ func runFirehose(ctx context.Context, cmd *cli.Command) error {
 		CollectionFilter: cmd.StringSlice("collection"),
 		Quiet:            cmd.Bool("quiet"),
 		Blocks:           cmd.Bool("blocks"),
+		Color:            colorEnabled(cmd),
 		VerifyBasic:      cmd.Bool("verify-basic"),
 		VerifySig:        cmd.Bool("verify-sig"),
 		VerifyMST:        cmd.Bool("verify-mst"),
@@ -224,7 +227,7 @@ func (gfc *GoatFirehoseConsumer) handleIdentityEvent(ctx context.Context, evt *c
 	if err != nil {
 		return err
 	}
-	fmt.Println(string(b))
+	gfc.println(b)
 	return nil
 }
 
@@ -244,7 +247,7 @@ func (gfc *GoatFirehoseConsumer) handleAccountEvent(ctx context.Context, evt *co
 	if err != nil {
 		return err
 	}
-	fmt.Println(string(b))
+	gfc.println(b)
 	return nil
 }
 
@@ -275,7 +278,7 @@ func (gfc *GoatFirehoseConsumer) handleSyncEvent(ctx context.Context, evt *comat
 	if err != nil {
 		return err
 	}
-	fmt.Println(string(b))
+	gfc.println(b)
 	return nil
 }
 
@@ -394,7 +397,7 @@ func (gfc *GoatFirehoseConsumer) handleCommitEvent(ctx context.Context, evt *com
 	if err != nil {
 		return err
 	}
-	fmt.Println(string(b))
+	gfc.println(b)
 	return nil
 }
 
@@ -470,7 +473,7 @@ func (gfc *GoatFirehoseConsumer) handleCommitEventOps(ctx context.Context, evt *
 				return err
 			}
 			if !gfc.Quiet {
-				fmt.Println(string(b))
+				gfc.println(b)
 			}
 		case "delete":
 			out["action"] = "delete"
@@ -479,11 +482,18 @@ func (gfc *GoatFirehoseConsumer) handleCommitEventOps(ctx context.Context, evt *
 				return err
 			}
 			if !gfc.Quiet {
-				fmt.Println(string(b))
+				gfc.println(b)
 			}
 		default:
 			logger.Error("unexpected record op kind")
 		}
 	}
 	return nil
+}
+
+func (gfc *GoatFirehoseConsumer) println(b []byte) {
+	if gfc.Color {
+		b = pretty.Color(b, nil)
+	}
+	fmt.Println(string(b))
 }

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/ipfs/go-ipld-cbor v0.2.1
 	github.com/ipfs/go-ipld-format v0.6.2
 	github.com/joho/godotenv v1.5.1
+	github.com/tidwall/pretty v1.2.1
 	github.com/urfave/cli/v3 v3.4.1
 	github.com/xlab/treeprint v1.2.0
 	github.com/yudai/gojsondiff v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -300,6 +300,8 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/tidwall/pretty v1.2.1 h1:qjsOFOWWQl+N3RsoF5/ssm1pHmJJwhjlSbZ51I6wMl4=
+github.com/tidwall/pretty v1.2.1/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
 github.com/urfave/cli v1.22.10/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/urfave/cli/v3 v3.4.1 h1:1M9UOCy5bLmGnuu1yn3t3CB4rG79Rtoxuv1sPhnm6qM=
 github.com/urfave/cli/v3 v3.4.1/go.mod h1:FJSKtM/9AiiTOJL4fJ6TbMUkxBXn7GO9guZqoZtpYpo=

--- a/identity.go
+++ b/identity.go
@@ -86,11 +86,9 @@ func runResolve(ctx context.Context, cmd *cli.Command) error {
 		}
 	}
 
-	b, err := json.MarshalIndent(raw, "", "  ")
-	if err != nil {
+	if err := printJSON(raw, colorEnabled(cmd)); err != nil {
 		return err
 	}
 
-	fmt.Println(string(b))
 	return nil
 }

--- a/lex.go
+++ b/lex.go
@@ -150,11 +150,9 @@ func runLexResolve(ctx context.Context, cmd *cli.Command) error {
 		return err
 	}
 
-	b, err := json.MarshalIndent(data, "", "  ")
-	if err != nil {
+	if err := printJSON(data, colorEnabled(cmd)); err != nil {
 		return err
 	}
-	fmt.Println(string(b))
 
 	return nil
 }

--- a/lex_breaking.go
+++ b/lex_breaking.go
@@ -89,11 +89,9 @@ func compareBreaking(ctx context.Context, cmd *cli.Command, nsid syntax.NSID, lo
 
 	if cmd.Bool("json") {
 		for _, iss := range issues {
-			b, err := json.Marshal(iss)
-			if err != nil {
+			if err := printJSON(iss, colorEnabled(cmd)); err != nil {
 				return nil
 			}
-			fmt.Println(string(b))
 		}
 	} else {
 		if len(issues) == 0 {

--- a/lex_lint.go
+++ b/lex_lint.go
@@ -94,11 +94,9 @@ func lintFilePath(ctx context.Context, cmd *cli.Command, p string) error {
 			Message:         err.Error(),
 		}
 		if cmd.Bool("json") {
-			b, err := json.Marshal(iss)
-			if err != nil {
+			if err := printJSON(iss, colorEnabled(cmd)); err != nil {
 				return nil
 			}
-			fmt.Println(string(b))
 		} else {
 			fmt.Printf(" 🔴 %s\n", p)
 			fmt.Printf("    [%s]: %s\n", iss.LintName, iss.Message)
@@ -129,11 +127,9 @@ func lintFilePath(ctx context.Context, cmd *cli.Command, p string) error {
 
 	if cmd.Bool("json") {
 		for _, iss := range issues {
-			b, err := json.Marshal(iss)
-			if err != nil {
+			if err := printJSON(iss, colorEnabled(cmd)); err != nil {
 				return nil
 			}
-			fmt.Println(string(b))
 		}
 	} else {
 		if len(issues) == 0 {

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/earthboundkid/versioninfo/v2"
 	"github.com/urfave/cli/v3"
+	"golang.org/x/term"
 )
 
 // this can be set at build time with: -ldflags="-X 'main.Version=X.Y.Z'"
@@ -16,9 +17,21 @@ var Version string
 
 func main() {
 	if err := run(os.Args); err != nil {
-		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		if term.IsTerminal(int(os.Stderr.Fd())) && os.Getenv("NO_COLOR") == "" {
+			fmt.Fprintf(os.Stderr, "\033[1;31merror:\033[0m %v\n", err)
+		} else {
+			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		}
 		os.Exit(-1)
 	}
+}
+
+func stderrIsTerminal() bool {
+	fi, err := os.Stderr.Stat()
+	if err != nil {
+		return false
+	}
+	return (fi.Mode() & os.ModeCharDevice) != 0
 }
 
 func run(args []string) error {
@@ -44,6 +57,10 @@ func run(args []string) error {
 				Value:   "https://plc.directory",
 				Sources: cli.EnvVars("ATP_PLC_HOST"),
 			},
+			&cli.BoolFlag{
+				Name:  "no-color",
+				Usage: "disable colored output",
+			},
 		},
 	}
 	app.Commands = []*cli.Command{
@@ -65,4 +82,12 @@ func run(args []string) error {
 		cmdRelay,
 	}
 	return app.Run(context.Background(), args)
+}
+
+func stderrIsTerminal() bool {
+	fi, err := os.Stderr.Stat()
+	if err != nil {
+		return false
+	}
+	return (fi.Mode() & os.ModeCharDevice) != 0
 }

--- a/pds.go
+++ b/pds.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -96,11 +95,9 @@ func runPDSDescribe(ctx context.Context, cmd *cli.Command) error {
 		return err
 	}
 
-	b, err := json.MarshalIndent(resp, "", "  ")
-	if err != nil {
+	if err := printJSON(resp, colorEnabled(cmd)); err != nil {
 		return err
 	}
-	fmt.Println(string(b))
 
 	return nil
 }
@@ -124,11 +121,9 @@ func runPDSAccountList(ctx context.Context, cmd *cli.Command) error {
 
 		for _, r := range resp.Repos {
 			if cmd.Bool("json") {
-				b, err := json.Marshal(r)
-				if err != nil {
+				if err := printJSON(r, colorEnabled(cmd)); err != nil {
 					return err
 				}
-				fmt.Println(string(b))
 			} else {
 				status := "unknown"
 				if r.Active != nil && *r.Active {
@@ -177,11 +172,7 @@ func runPDSAccountStatus(ctx context.Context, cmd *cli.Command) error {
 	}
 
 	if cmd.Bool("json") {
-		b, err := json.Marshal(r)
-		if err != nil {
-			return err
-		}
-		fmt.Println(string(b))
+		return printJSON(r, colorEnabled(cmd))
 	} else {
 		status := "unknown"
 		if r.Active {

--- a/pds_admin.go
+++ b/pds_admin.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"context"
 	"crypto/rand"
-	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
@@ -246,11 +245,9 @@ func runPDSAdminAccountList(ctx context.Context, cmd *cli.Command) error {
 
 		for _, r := range resp.Repos {
 			if cmd.Bool("json") {
-				b, err := json.Marshal(r)
-				if err != nil {
+				if err := printJSON(r, colorEnabled(cmd)); err != nil {
 					return err
 				}
-				fmt.Println(string(b))
 			} else {
 				status := "unknown"
 				if r.Active != nil && *r.Active {
@@ -311,12 +308,7 @@ func runPDSAdminAccountInfo(ctx context.Context, cmd *cli.Command) error {
 	if err != nil {
 		return err
 	}
-	b, err := json.MarshalIndent(r, "", "  ")
-	if err != nil {
-		return err
-	}
-	fmt.Println(string(b))
-	return nil
+	return printJSON(r, colorEnabled(cmd))
 }
 
 func runPDSAdminAccountUpdate(ctx context.Context, cmd *cli.Command) error {
@@ -421,12 +413,7 @@ func runPDSAdminBlobStatus(ctx context.Context, cmd *cli.Command) error {
 	if err != nil {
 		return err
 	}
-	b, err := json.MarshalIndent(resp, "", "  ")
-	if err != nil {
-		return err
-	}
-	fmt.Println(string(b))
-	return nil
+	return printJSON(resp, colorEnabled(cmd))
 }
 
 func runPDSAdminBlobPurge(ctx context.Context, cmd *cli.Command) error {

--- a/plc.go
+++ b/plc.go
@@ -228,11 +228,9 @@ func runPLCHistory(ctx context.Context, cmd *cli.Command) error {
 	}
 
 	for _, op := range oplog {
-		b, err := json.MarshalIndent(op, "", "  ")
-		if err != nil {
+		if err := printJSON(op, colorEnabled(cmd)); err != nil {
 			return err
 		}
-		fmt.Println(string(b))
 	}
 
 	return nil
@@ -280,12 +278,7 @@ func runPLCData(ctx context.Context, cmd *cli.Command) error {
 		return err
 	}
 
-	b, err := json.MarshalIndent(plcData, "", "  ")
-	if err != nil {
-		return err
-	}
-	fmt.Println(string(b))
-	return nil
+	return printJSON(plcData, colorEnabled(cmd))
 }
 
 func runPLCDump(ctx context.Context, cmd *cli.Command) error {
@@ -355,11 +348,9 @@ func runPLCDump(ctx context.Context, cmd *cli.Command) error {
 				continue
 			}
 
-			b, err := json.Marshal(op)
-			if err != nil {
+			if err := printJSON(op, colorEnabled(cmd)); err != nil {
 				return err
 			}
-			fmt.Println(string(b))
 		}
 		if cursor != "" && cursor == lastCursor {
 			if tailMode {
@@ -467,13 +458,7 @@ func runPLCGenesis(ctx context.Context, cmd *cli.Command) error {
 		}
 	}
 
-	res, err := json.MarshalIndent(op, "", "  ")
-	if err != nil {
-		return err
-	}
-	fmt.Println(string(res))
-
-	return nil
+	return printJSON(op, colorEnabled(cmd))
 }
 
 func runPLCCalcDID(ctx context.Context, cmd *cli.Command) error {
@@ -547,13 +532,7 @@ func runPLCSign(ctx context.Context, cmd *cli.Command) error {
 		return err
 	}
 
-	res, err := json.MarshalIndent(op, "", "  ")
-	if err != nil {
-		return err
-	}
-	fmt.Println(string(res))
-
-	return nil
+	return printJSON(op, colorEnabled(cmd))
 }
 
 func runPLCSubmit(ctx context.Context, cmd *cli.Command) error {
@@ -750,11 +729,5 @@ func runPLCUpdate(ctx context.Context, cmd *cli.Command) error {
 		}
 	}
 
-	res, err := json.MarshalIndent(op, "", "  ")
-	if err != nil {
-		return err
-	}
-	fmt.Println(string(res))
-
-	return nil
+	return printJSON(op, colorEnabled(cmd))
 }

--- a/record.go
+++ b/record.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -131,12 +130,10 @@ func runRecordGet(ctx context.Context, cmd *cli.Command) error {
 		return err
 	}
 
-	b, err := json.MarshalIndent(record, "", "  ")
-	if err != nil {
+	if err := printJSON(record, colorEnabled(cmd)); err != nil {
 		return err
 	}
 
-	fmt.Println(string(b))
 	return nil
 }
 

--- a/relay.go
+++ b/relay.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"sort"
 
@@ -152,11 +151,9 @@ func runRelayAccountList(ctx context.Context, cmd *cli.Command) error {
 
 			for _, r := range resp.Repos {
 				if cmd.Bool("json") {
-					b, err := json.Marshal(r)
-					if err != nil {
+					if err := printJSON(r, colorEnabled(cmd)); err != nil {
 						return err
 					}
-					fmt.Println(string(b))
 				} else {
 					status := "unknown"
 					if r.Active != nil && *r.Active {
@@ -201,11 +198,7 @@ func runRelayAccountStatus(ctx context.Context, cmd *cli.Command) error {
 	}
 
 	if cmd.Bool("json") {
-		b, err := json.Marshal(r)
-		if err != nil {
-			return err
-		}
-		fmt.Println(string(b))
+		return printJSON(r, colorEnabled(cmd))
 	} else {
 		status := "unknown"
 		if r.Active {
@@ -263,11 +256,9 @@ func runRelayHostList(ctx context.Context, cmd *cli.Command) error {
 
 		for _, h := range resp.Hosts {
 			if cmd.Bool("json") {
-				b, err := json.Marshal(h)
-				if err != nil {
+				if err := printJSON(h, colorEnabled(cmd)); err != nil {
 					return err
 				}
-				fmt.Println(string(b))
 			} else {
 				status := ""
 				if h.Status != nil {
@@ -312,11 +303,7 @@ func runRelayHostStatus(ctx context.Context, cmd *cli.Command) error {
 	}
 
 	if cmd.Bool("json") {
-		b, err := json.Marshal(h)
-		if err != nil {
-			return err
-		}
-		fmt.Println(string(b))
+		return printJSON(h, colorEnabled(cmd))
 	} else {
 		status := ""
 		if h.Status != nil {

--- a/relay_admin.go
+++ b/relay_admin.go
@@ -339,11 +339,9 @@ func runRelayAdminHostList(ctx context.Context, cmd *cli.Command) error {
 		return err
 	}
 	for _, r := range rows {
-		b, err := json.Marshal(r)
-		if err != nil {
+		if err := printJSON(r, colorEnabled(cmd)); err != nil {
 			return nil
 		}
-		fmt.Println(string(b))
 	}
 	return nil
 }
@@ -440,11 +438,9 @@ func runRelayAdminConsumerList(ctx context.Context, cmd *cli.Command) error {
 		return err
 	}
 	for _, r := range rows {
-		b, err := json.Marshal(r)
-		if err != nil {
+		if err := printJSON(r, colorEnabled(cmd)); err != nil {
 			return nil
 		}
-		fmt.Println(string(b))
 	}
 	return nil
 }

--- a/util.go
+++ b/util.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"log/slog"
@@ -12,7 +13,9 @@ import (
 	"github.com/bluesky-social/indigo/atproto/syntax"
 
 	"github.com/earthboundkid/versioninfo/v2"
+	"github.com/tidwall/pretty"
 	"github.com/urfave/cli/v3"
+	"golang.org/x/term"
 )
 
 // helper to configure identity directory with PLC host (from env var) and user agent
@@ -123,4 +126,25 @@ func parseDIDRef(raw string) error {
 	}
 	// TODO: more syntax checks on fragment
 	return nil
+}
+func printJSON(v any, useColor bool) error {
+	b, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return err
+	}
+	if useColor {
+		b = pretty.Color(b, nil)
+	}
+	fmt.Println(string(b))
+	return nil
+}
+
+func colorEnabled(cmd *cli.Command) bool {
+	if cmd.Bool("no-color") {
+		return false
+	}
+	if os.Getenv("NO_COLOR") != "" {
+		return false
+	}
+	return term.IsTerminal(int(os.Stdout.Fd()))
 }

--- a/xrpc.go
+++ b/xrpc.go
@@ -174,12 +174,16 @@ func runXrpc(ctx context.Context, cmd *cli.Command) error {
 		return eb.APIError(resp.StatusCode)
 	}
 
-	// only if TTY output...
 	if term.IsTerminal(int(os.Stdout.Fd())) {
-		fmt.Printf("%s %s\n", resp.Proto, resp.Status)
+		useColor := colorEnabled(cmd)
+		statusFmt, headerFmt := "%s %s\n", "%s: %s\n"
+		if useColor {
+			statusFmt, headerFmt = "\033[32m%s %s\033[0m\n", "\033[36m%s\033[0m: %s\n"
+		}
+		fmt.Printf(statusFmt, resp.Proto, resp.Status)
 		for name, vals := range resp.Header {
 			for _, v := range vals {
-				fmt.Printf("%s: %s\n", name, v)
+				fmt.Printf(headerFmt, name, v)
 			}
 		}
 		fmt.Println()
@@ -190,11 +194,5 @@ func runXrpc(ctx context.Context, cmd *cli.Command) error {
 		return fmt.Errorf("failed decoding JSON response body: %w", err)
 	}
 
-	b, err := json.MarshalIndent(respBody, "", "  ")
-	if err != nil {
-		return err
-	}
-	fmt.Println(string(b))
-
-	return nil
+	return printJSON(respBody, colorEnabled(cmd))
 }


### PR DESCRIPTION
- Adds JSON colorization to CLI output with ANSI colors (on by default, can be disabled with `--no-color` flag or `NO_COLOR` env var)
- Detects when output is being piped and skips colorization
- Also colorizes `error:` in error messages (this could probably be expanded upon later on)

Screenshots:

`goat resolve`:
<img width="1264" height="870" alt="image" src="https://github.com/user-attachments/assets/c685113c-663d-4641-8bff-01d851c5a4a3" />

`goat record get`:n
<img width="1760" height="488" alt="image" src="https://github.com/user-attachments/assets/98b2ecc2-f4bd-4ecb-83ea-4d33131cfe4f" />

`goat firehose`:
<img width="1264" height="547" alt="image" src="https://github.com/user-attachments/assets/ea5a62b2-3a7d-4669-b325-a320926a3732" />

`error message`:
<img width="772" height="69" alt="image" src="https://github.com/user-attachments/assets/35b3e4f1-379e-4ff1-bf6b-ee8eb1371954" />

`record get` piped to file:
<img width="1491" height="450" alt="image" src="https://github.com/user-attachments/assets/785007f4-6684-45a1-87e5-7a6e0b76d180" />

If necessary, I'd be happy to add some test cases as well.