### PR TITLE
feat: lex status: add legend explaining colored icons

### DIFF
--- a/lex_status.go
+++ b/lex_status.go
@@ -29,7 +29,14 @@ var cmdLexStatus = &cli.Command{
 }
 
 func runLexStatus(ctx context.Context, cmd *cli.Command) error {
-	return runComparisons(ctx, cmd, compareStatus)
+	err := runComparisons(ctx, cmd, compareStatus)
+	fmt.Println()
+	fmt.Println("Legend:")
+	fmt.Println(" 🟢 in sync")
+	fmt.Println(" 🟣 local and remote differ")
+	fmt.Println(" 🟠 local only (not yet published)")
+	fmt.Println(" ⭕ remote only (missing locally)")
+	return err
 }
 
 func compareStatus(ctx context.Context, cmd *cli.Command, nsid syntax.NSID, localJSON, remoteJSON json.RawMessage) error {

--- a/lex_status.go
+++ b/lex_status.go
@@ -15,7 +15,7 @@ import (
 var cmdLexStatus = &cli.Command{
 	Name:        "status",
 	Usage:       "check if local lexicons are in-sync with live network",
-	Description: "Enumerates all local lexicons (JSON files), and checks for changes against the live network\nWill detect new published lexicons under a known lexicon group, but will not discover new groups under the same domain prefix.\nOperates on entire ./lexicons/ directory unless specific files or directories are provided.",
+	Description: "Enumerates all local lexicons (JSON files), and checks for changes against the live network\nWill detect new published lexicons under a known lexicon group, but will not discover new groups under the same domain prefix.\nOperates on entire ./lexicons/ directory unless specific files or directories are provided.\n\nLegend:\n 🟢 in sync\n 🟣 local and remote differ\n 🟠 local only (not yet published)\n ⭕ remote only (missing locally)",
 	ArgsUsage:   `<file-or-dir>*`,
 	Flags: []cli.Flag{
 		&cli.StringFlag{


### PR DESCRIPTION
## Summary

- Documents the colored status icons (🟢 in sync, 🟣 differ, 🟠 local only, ⭕ remote only) in the `goat lex status` help text, so the legend appears under `goat lex status -h` rather than being printed on every invocation.

Fixes #38