### PR TITLE
fix: Edit readme for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ goat help bsky
 # etc
 ```
 
-Most commands use public APIs are don't require authentication. Some commands, like creating records, require an atproto account. You can log in using an "app password" with `goat account login -u <handle> -p <password>`.
+Most commands use public APIs and don't require authentication. Some commands, like creating records, require an atproto account. You can log in using an "app password" with `goat account login -u <handle> -p <password>`.
 
 WARNING: `goat` will store both the app password and authentication tokens in the current users home directory, in cleartext. `goat account logout` will wipe the file. Intention is to eventually support configuration via environment variables to keep sensitive state in a password manager or otherwise not-cleartext-on-disk.
 


### PR DESCRIPTION
Fixed some typos on README.md for clarity.

1) ``goat logout will wipe the file`` should read  ``goat account logout will wipe the file.``

2) Missing example command should read:
``goat blob export jay.bsky.team``

3) ``Most commands use public APIS are don't require authentication`` should read ``Most commands use public APIs and don't require authentication``