### PR TITLE
fix: clearer error message in `goat lex publish`

### DIFF
--- a/lex_publish.go
+++ b/lex_publish.go
@@ -63,8 +63,10 @@ publish behavior:
 func runLexPublish(ctx context.Context, cmd *cli.Command) error {
 
 	c, err := loginOrLoadAuthClient(ctx, cmd)
-	if err != nil {
-		return nil
+	if err == ErrNoAuthSession {
+		return fmt.Errorf("auth required, but not logged in")
+	} else if err != nil {
+		return err
 	}
 
 	if c.AccountDID == nil {


### PR DESCRIPTION
Hi there! I was trying to follow [these docs on publishing lexicons](https://atproto.com/guides/publishing-lexicons) and I was briefly confused by the lack of an output when running `goat lex publish`. Turns out, I needed to log in!

I noticed when spelunking the code that [the error from `loginOrLoadAuthClient` is swallowed](https://github.com/bluesky-social/goat/blob/ceb900cac76e860c918fe061aaaa50bdc4434ebe/lex_publish.go#L65-L68). This PR fixes that.

I tried to follow the convention [used in other parts of the codebase](https://github.com/kanadgupta/goat/blob/8b0b45f6c02b79bde3516dc806d95cb99e42fae2/account_migrate.go#L63-L67). Feel free to make any changes as needed. Thanks in advance for the review and thanks for your work on this tool!