### PR TITLE
XRPC sub-command for calling HTTP API endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,24 @@ A minimal bsky posting interface, requires account login:
 $ goat bsky post "hello from goat"
 ```
 
+The `xrpc` command can be used to make HTTP API calls. These can be authenticated (eg, proxy via PDS), or direct to hostnames:
+
+```bash
+# call an XRPC endpoint (HTTP GET) on an unauthenticated host
+$ goat xrpc query https://public.api.bsky.app app.bsky.actor.getProfile actor==atproto.com
+
+# make an authenticated PDS proxy call (HTTP GET) to a remote XRPC service, identified by DID service reference, and with a custom label header set
+$ goat xrpc query did:web:api.bsky.app#bsky_appview app.bsky.actor.getProfile actor==atproto.com Atproto-Accept-Labelers:did:plc:d2mkddsbmnrgr3domzg5qexf
+
+# make an authenticated XRPC call (HTTP POST) to the authenticated user's PDS instance. in this case, upload a blob from a file, with mediatype specified
+# note that 'goat blob upload' provides the same functionality
+goat xrpc procedure @pds com.atproto.repo.uploadBlob Content-Type:image/png - < ./image.png
+
+# make an authenticated XRPC call to the PDS. in this case, create a dummy record, demonstrating how to construct trequest body fields via args
+# note that 'goat record create' provides the same functionality
+goat xrpc procedure @pds com.atproto.repo.createRecord repo=did:plc:abc123 collection=example.nsid.record rkey=goat01 validate:=false 'record:={"text": "hello"}'
+```
+
 ## Lexicon Development
 
 In a project directory, download some existing schemas, which will get saved as JSON files in `./lexicons/`:

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/urfave/cli/v3 v3.4.1
 	github.com/xlab/treeprint v1.2.0
 	github.com/yudai/gojsondiff v1.0.0
+	golang.org/x/term v0.34.0
 	tangled.org/bnewbold.net/cobalt v0.0.0-20251130012119-37226a9573e6
 )
 

--- a/go.sum
+++ b/go.sum
@@ -388,6 +388,8 @@ golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.35.0 h1:vz1N37gP5bs89s7He8XuIYXpyY0+QlsKmzipCbUtyxI=
 golang.org/x/sys v0.35.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
+golang.org/x/term v0.34.0 h1:O/2T7POpk0ZZ7MAzMeWFSg6S5IpWd/RXDlM9hgM3DR4=
+golang.org/x/term v0.34.0/go.mod h1:5jC53AEywhIVebHgPVeg0mj8OD3VO9OzclacVrqpaAw=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.28.0 h1:rhazDwis8INMIwQ4tpjLDzUhx6RlXqZNPEM0huQojng=

--- a/main.go
+++ b/main.go
@@ -51,6 +51,7 @@ func run(args []string) error {
 		cmdRecordList,
 		cmdFirehose,
 		cmdResolve,
+		cmdXrpc,
 		cmdRepo,
 		cmdBlob,
 		cmdLex,

--- a/util.go
+++ b/util.go
@@ -107,3 +107,20 @@ func configLogger(cmd *cli.Command, writer io.Writer) *slog.Logger {
 func userAgentString() string {
 	return fmt.Sprintf("goat/%s", versioninfo.Short())
 }
+
+// attempts to parse a DID-and-reference string
+func parseDIDRef(raw string) error {
+	parts := strings.SplitN(raw, "#", 3)
+	if len(parts) != 2 {
+		return fmt.Errorf("not a DID-and-fragment")
+	}
+	_, err := syntax.ParseDID(parts[0])
+	if err != nil {
+		return err
+	}
+	if len(parts[1]) == 0 {
+		return fmt.Errorf("empty fragment")
+	}
+	// TODO: more syntax checks on fragment
+	return nil
+}

--- a/xrpc.go
+++ b/xrpc.go
@@ -1,24 +1,26 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"os"
 	"strings"
 
 	"github.com/bluesky-social/indigo/atproto/atclient"
 	"github.com/bluesky-social/indigo/atproto/syntax"
 
 	"github.com/urfave/cli/v3"
+	"golang.org/x/term"
 )
 
 var cmdXrpc = &cli.Command{
-	Name:      "xrpc",
-	Usage:     "call remote XRPC (HTTP API) endpoints",
-	ArgsUsage: `<method> <service> <endpoint> [args...]`,
-	// TODO: longer description
-	Description: "Flexible tool for calling arbitrary XRPC endpoints on remote services",
+	Name:        "xrpc",
+	Usage:       "call remote XRPC (HTTP API) endpoints",
+	ArgsUsage:   `<method> <service> <endpoint> [args...]`,
+	Description: "Flexible tool for calling arbitrary XRPC endpoints on remote services. Supports multiple types of service endpoint resolution and auth.\n'method' is the HTTP/XRPC method type (eg 'query' or 'procedure').\n'service' identifies the remote host. Provide an HTTP/HTTPS base URL for direct connections, or a service DID reference for authenticated PDS proxying.\n'endpoint' is an NSID identifying the API endpoint.\nAdditional args follow HTTPie CLI syntax: 'key==value' sets a query param, 'key=value' sets a JSON request body string field; 'key:=123' sets a non-string field",
 	Flags: []cli.Flag{
 		&cli.StringFlag{
 			Name:    "admin-password",
@@ -52,7 +54,7 @@ func runXrpc(ctx context.Context, cmd *cli.Command) error {
 	case "post", "procedure":
 		method = atclient.MethodProcedure
 	default:
-		return fmt.Errorf("unknown method type: %s", method)
+		return fmt.Errorf("unknown XRPC method type: %s", method)
 	}
 
 	rawService := cmd.Args().Get(1)
@@ -84,8 +86,7 @@ func runXrpc(ctx context.Context, cmd *cli.Command) error {
 		}
 
 		if cmd.IsSet("service-auth-key") && cmd.IsSet("service-auth-iss") {
-			// service auth mode
-			// TODO
+			// TODO: service auth mode
 			return fmt.Errorf("service auth mode is unimplemented")
 		} else {
 			// PDS service proxy mode
@@ -103,28 +104,52 @@ func runXrpc(ctx context.Context, cmd *cli.Command) error {
 	for i := range cmd.Args().Len() - 3 {
 		arg := cmd.Args().Get(i + 3)
 		if strings.HasPrefix(arg, "@") {
-			// XXX: load request body from disk
+			p, _ := strings.CutPrefix(arg, "@")
+			b, err := os.ReadFile(p)
+			if err != nil {
+				return fmt.Errorf("could not read request body file: %w", err)
+			}
+			if err := json.NewDecoder(bytes.NewReader(b)).Decode(&reqBody); err != nil {
+				return fmt.Errorf("invalid JSON file contents: %w", err)
+			}
 		} else if strings.Contains(arg, "==") {
 			parts := strings.SplitN(arg, "==", 2)
 			if len(parts[0]) == 0 {
 				return fmt.Errorf("empty query parameter name")
 			}
 			params.Add(parts[0], parts[1])
+		} else if strings.Contains(arg, ":=") {
+			parts := strings.SplitN(arg, ":=", 2)
+			if len(parts[0]) == 0 {
+				return fmt.Errorf("empty body field name")
+			}
+			var val any
+			if err := json.NewDecoder(bytes.NewReader([]byte(parts[1]))).Decode(&val); err != nil {
+				return fmt.Errorf("invalid non-string field value: %w", err)
+			}
+			reqBody[parts[0]] = val
 		} else if strings.Contains(arg, "=") {
 			parts := strings.SplitN(arg, "=", 2)
 			if len(parts[0]) == 0 {
-				return fmt.Errorf("empty query parameter name")
+				return fmt.Errorf("empty body field name")
 			}
 			reqBody[parts[0]] = parts[1]
 		} else {
-			// XXX: parse more additional args (eg, :=)
 			return fmt.Errorf("unhandled arg syntax: %s", arg)
 		}
 	}
 
 	req := atclient.NewAPIRequest(method, endpoint, nil)
 	req.Headers.Set("Accept", "application/json")
-	//req.Headers.Set("Content-Type", "application/json")
+
+	if method == atclient.MethodProcedure {
+		bodyJSON, err := json.Marshal(reqBody)
+		if err != nil {
+			return err
+		}
+		req.Body = bytes.NewReader(bodyJSON)
+		req.Headers.Set("Content-Type", "application/json")
+	}
 
 	if len(params) > 0 {
 		req.QueryParams = params
@@ -144,18 +169,27 @@ func runXrpc(ctx context.Context, cmd *cli.Command) error {
 		return eb.APIError(resp.StatusCode)
 	}
 
-	// XXX: do something with body and headers
-	for name, val := range resp.Header {
-		fmt.Println("%s: %s", name, val)
+	// only if TTY output...
+	if term.IsTerminal(int(os.Stdout.Fd())) {
+		fmt.Printf("%s %s\n", resp.Proto, resp.Status)
+		for name, vals := range resp.Header {
+			for _, v := range vals {
+				fmt.Printf("%s: %s\n", name, v)
+			}
+		}
+		fmt.Println()
 	}
-	fmt.Println()
 
 	var respBody json.RawMessage
-	if err := json.NewDecoder(resp.Body).Decode(respBody); err != nil {
+	if err := json.NewDecoder(resp.Body).Decode(&respBody); err != nil {
 		return fmt.Errorf("failed decoding JSON response body: %w", err)
 	}
 
-	fmt.Println(respBody)
+	b, err := json.MarshalIndent(respBody, "", "  ")
+	if err != nil {
+		return err
+	}
+	fmt.Println(string(b))
 
 	return nil
 }

--- a/xrpc.go
+++ b/xrpc.go
@@ -1,0 +1,161 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/bluesky-social/indigo/atproto/atclient"
+	"github.com/bluesky-social/indigo/atproto/syntax"
+
+	"github.com/urfave/cli/v3"
+)
+
+var cmdXrpc = &cli.Command{
+	Name:      "xrpc",
+	Usage:     "call remote XRPC (HTTP API) endpoints",
+	ArgsUsage: `<method> <service> <endpoint> [args...]`,
+	// TODO: longer description
+	Description: "Flexible tool for calling arbitrary XRPC endpoints on remote services",
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:    "admin-password",
+			Usage:   "admin password (for admin auth calls)",
+			Sources: cli.EnvVars("ADMIN_PASSWORD", "ATP_AUTH_ADMIN_PASSWORD"),
+		},
+		&cli.StringFlag{
+			Name:    "service-auth-key",
+			Usage:   "secret key for service auth (multikey encoding)",
+			Sources: cli.EnvVars("SERVICE_AUTH_KEY"),
+		},
+		&cli.StringFlag{
+			Name:    "service-auth-iss",
+			Usage:   "issuer DID for service auth",
+			Sources: cli.EnvVars("SERVICE_AUTH_ISS"),
+		},
+	},
+	Action: runXrpc,
+}
+
+func runXrpc(ctx context.Context, cmd *cli.Command) error {
+
+	if cmd.Args().Len() < 3 {
+		return fmt.Errorf("most provide at least service and NSID args")
+	}
+
+	method := cmd.Args().Get(0)
+	switch strings.ToLower(method) {
+	case "get", "query":
+		method = atclient.MethodQuery
+	case "post", "procedure":
+		method = atclient.MethodProcedure
+	default:
+		return fmt.Errorf("unknown method type: %s", method)
+	}
+
+	rawService := cmd.Args().Get(1)
+
+	endpoint, err := syntax.ParseNSID(cmd.Args().Get(2))
+	if err != nil {
+		return fmt.Errorf("endpoint arg must be an NSID: %w", err)
+	}
+
+	var client *atclient.APIClient
+
+	if rawService == "_pds" {
+		// authenticated PDS mode
+		client, err = loadAuthClient(ctx, cmd)
+		if err != nil {
+			return fmt.Errorf("PDS API requests require session: %w", err)
+		}
+	} else if strings.Contains(rawService, "://") {
+		if cmd.IsSet("admin-password") {
+			// admin auth mode
+			client = atclient.NewAdminClient(rawService, cmd.String("admin-password"))
+		} else {
+			// public API endpoint mode
+			client = atclient.NewAPIClient(rawService)
+		}
+	} else {
+		if err := parseDIDRef(rawService); err != nil {
+			return fmt.Errorf("unknown service type: %s", rawService)
+		}
+
+		if cmd.IsSet("service-auth-key") && cmd.IsSet("service-auth-iss") {
+			// service auth mode
+			// TODO
+			return fmt.Errorf("service auth mode is unimplemented")
+		} else {
+			// PDS service proxy mode
+			client, err = loadAuthClient(ctx, cmd)
+			if err != nil {
+				return fmt.Errorf("PDS proxied requests require session: %w", err)
+			}
+			client = client.WithService(rawService)
+		}
+	}
+
+	params := make(url.Values)
+	reqBody := make(map[string]any)
+
+	for i := range cmd.Args().Len() - 3 {
+		arg := cmd.Args().Get(i + 3)
+		if strings.HasPrefix(arg, "@") {
+			// XXX: load request body from disk
+		} else if strings.Contains(arg, "==") {
+			parts := strings.SplitN(arg, "==", 2)
+			if len(parts[0]) == 0 {
+				return fmt.Errorf("empty query parameter name")
+			}
+			params.Add(parts[0], parts[1])
+		} else if strings.Contains(arg, "=") {
+			parts := strings.SplitN(arg, "=", 2)
+			if len(parts[0]) == 0 {
+				return fmt.Errorf("empty query parameter name")
+			}
+			reqBody[parts[0]] = parts[1]
+		} else {
+			// XXX: parse more additional args (eg, :=)
+			return fmt.Errorf("unhandled arg syntax: %s", arg)
+		}
+	}
+
+	req := atclient.NewAPIRequest(method, endpoint, nil)
+	req.Headers.Set("Accept", "application/json")
+	//req.Headers.Set("Content-Type", "application/json")
+
+	if len(params) > 0 {
+		req.QueryParams = params
+	}
+
+	resp, err := client.Do(ctx, req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if !(resp.StatusCode >= 200 && resp.StatusCode < 300) {
+		var eb atclient.ErrorBody
+		if err := json.NewDecoder(resp.Body).Decode(&eb); err != nil {
+			return &atclient.APIError{StatusCode: resp.StatusCode}
+		}
+		return eb.APIError(resp.StatusCode)
+	}
+
+	// XXX: do something with body and headers
+	for name, val := range resp.Header {
+		fmt.Println("%s: %s", name, val)
+	}
+	fmt.Println()
+
+	var respBody json.RawMessage
+	if err := json.NewDecoder(resp.Body).Decode(respBody); err != nil {
+		return fmt.Errorf("failed decoding JSON response body: %w", err)
+	}
+
+	fmt.Println(respBody)
+
+	return nil
+}

--- a/xrpc.go
+++ b/xrpc.go
@@ -20,22 +20,12 @@ var cmdXrpc = &cli.Command{
 	Name:        "xrpc",
 	Usage:       "call remote XRPC (HTTP API) endpoints",
 	ArgsUsage:   `<method> <service> <endpoint> [args...]`,
-	Description: "Flexible tool for calling arbitrary XRPC endpoints on remote services. Supports multiple types of service endpoint resolution and auth.\n'method' is the HTTP/XRPC method type (eg 'query' or 'procedure').\n'service' identifies the remote host. Provide an HTTP/HTTPS base URL for direct connections, or a service DID reference for authenticated PDS proxying.\n'endpoint' is an NSID identifying the API endpoint.\nAdditional args follow HTTPie CLI syntax: 'key==value' sets a query param, 'key=value' sets a JSON request body string field; 'key:=123' sets a non-string field",
+	Description: "Flexible tool for calling arbitrary XRPC endpoints on remote services. Supports multiple types of service endpoint resolution and auth.\n'method' is the HTTP/XRPC method type (eg 'query' or 'procedure').\n'service' identifies the remote host. Provide an HTTP/HTTPS base URL for direct connections, or a service DID reference for authenticated PDS proxying. Provide '@pds' for authenticated requests to the current account PDS.\n'endpoint' is an NSID identifying the API endpoint.\nAdditional args follow HTTPie CLI syntax: 'key==value' sets a query param, 'key=value' sets a JSON request body string field; 'key:=123' sets a non-string JSON request body field; 'key:value' sets an HTTP request header; '-' reads a request body from stdin (may need to specify Content-Type header)",
 	Flags: []cli.Flag{
 		&cli.StringFlag{
 			Name:    "admin-password",
 			Usage:   "admin password (for admin auth calls)",
 			Sources: cli.EnvVars("ADMIN_PASSWORD", "ATP_AUTH_ADMIN_PASSWORD"),
-		},
-		&cli.StringFlag{
-			Name:    "service-auth-key",
-			Usage:   "secret key for service auth (multikey encoding)",
-			Sources: cli.EnvVars("SERVICE_AUTH_KEY"),
-		},
-		&cli.StringFlag{
-			Name:    "service-auth-iss",
-			Usage:   "issuer DID for service auth",
-			Sources: cli.EnvVars("SERVICE_AUTH_ISS"),
 		},
 	},
 	Action: runXrpc,
@@ -66,7 +56,7 @@ func runXrpc(ctx context.Context, cmd *cli.Command) error {
 
 	var client *atclient.APIClient
 
-	if rawService == "_pds" {
+	if rawService == "@pds" {
 		// authenticated PDS mode
 		client, err = loadAuthClient(ctx, cmd)
 		if err != nil {
@@ -85,24 +75,30 @@ func runXrpc(ctx context.Context, cmd *cli.Command) error {
 			return fmt.Errorf("unknown service type: %s", rawService)
 		}
 
-		if cmd.IsSet("service-auth-key") && cmd.IsSet("service-auth-iss") {
-			// TODO: service auth mode
-			return fmt.Errorf("service auth mode is unimplemented")
-		} else {
-			// PDS service proxy mode
-			client, err = loadAuthClient(ctx, cmd)
-			if err != nil {
-				return fmt.Errorf("PDS proxied requests require session: %w", err)
-			}
-			client = client.WithService(rawService)
+		// TODO: raw service auth mode would go here
+
+		// PDS service proxy mode
+		client, err = loadAuthClient(ctx, cmd)
+		if err != nil {
+			return fmt.Errorf("PDS proxied requests require session: %w", err)
 		}
+		client = client.WithService(rawService)
 	}
 
 	params := make(url.Values)
 	reqBody := make(map[string]any)
+	reqStdin := false
+
+	req := atclient.NewAPIRequest(method, endpoint, nil)
+	req.Headers.Set("Accept", "application/json")
 
 	for i := range cmd.Args().Len() - 3 {
 		arg := cmd.Args().Get(i + 3)
+		if arg == "-" {
+			reqStdin = true
+			continue
+		}
+		// TODO: all this pattern matching is informal and not correct in corner-cases
 		if strings.HasPrefix(arg, "@") {
 			p, _ := strings.CutPrefix(arg, "@")
 			b, err := os.ReadFile(p)
@@ -128,6 +124,12 @@ func runXrpc(ctx context.Context, cmd *cli.Command) error {
 				return fmt.Errorf("invalid non-string field value: %w", err)
 			}
 			reqBody[parts[0]] = val
+		} else if strings.Contains(arg, ":") {
+			parts := strings.SplitN(arg, ":", 2)
+			if len(parts[0]) == 0 {
+				return fmt.Errorf("empty request header name")
+			}
+			req.Headers.Set(parts[0], parts[1])
 		} else if strings.Contains(arg, "=") {
 			parts := strings.SplitN(arg, "=", 2)
 			if len(parts[0]) == 0 {
@@ -139,16 +141,19 @@ func runXrpc(ctx context.Context, cmd *cli.Command) error {
 		}
 	}
 
-	req := atclient.NewAPIRequest(method, endpoint, nil)
-	req.Headers.Set("Accept", "application/json")
-
 	if method == atclient.MethodProcedure {
-		bodyJSON, err := json.Marshal(reqBody)
-		if err != nil {
-			return err
+		if req.Headers.Get("Content-Type") == "" {
+			req.Headers.Set("Content-Type", "application/json")
 		}
-		req.Body = bytes.NewReader(bodyJSON)
-		req.Headers.Set("Content-Type", "application/json")
+		if reqStdin {
+			req.Body = os.Stdin
+		} else {
+			bodyJSON, err := json.Marshal(reqBody)
+			if err != nil {
+				return err
+			}
+			req.Body = bytes.NewReader(bodyJSON)
+		}
 	}
 
 	if len(params) > 0 {


### PR DESCRIPTION
```
NAME:
   goat xrpc - call remote XRPC (HTTP API) endpoints

USAGE:
   goat xrpc [options] <method> <service> <endpoint> [args...]

DESCRIPTION:
   Flexible tool for calling arbitrary XRPC endpoints on remote services. Supports multiple types of service endpoint resolution and auth.
   'method' is the HTTP/XRPC method type (eg 'query' or 'procedure').
   'service' identifies the remote host. Provide an HTTP/HTTPS base URL for direct connections, or a service DID reference for authenticated PDS proxying. Provide '@pds' for authenticated requests to the current account PDS.
   'endpoint' is an NSID identifying the API endpoint.
   Additional args follow HTTPie CLI syntax: 'key==value' sets a query param, 'key=value' sets a JSON request body string field; 'key:=123' sets a non-string JSON request body field; 'key:value' sets an HTTP request header; '-' reads a request body from stdin (may need to specify Content-Type header)

OPTIONS:
   --admin-password string  admin password (for admin auth calls) [$ADMIN_PASSWORD, $ATP_AUTH_ADMIN_PASSWORD]
   --help, -h               show help

GLOBAL OPTIONS:
   --log-level string  log verbosity level (eg: warn, info, debug) [$GOAT_LOG_LEVEL, $GO_LOG_LEVEL, $LOG_LEVEL]
   --plc-host string   method, hostname, and port of PLC directory (default: "https://plc.directory") [$ATP_PLC_HOST]
```

Examples (more in the README update):

```
# public unauthenticated request
goat xrpc query https://api.bsky.app app.bsky.actor.getProfile actor==atproto.com

# authenticated PDS proxy request
goat xrpc query did:web:api.bsky.app#bsky_appview app.bsky.actor.getProfile actor==atproto.com
```

I want to support many ways XRPC calls happen, though i'm not trying to cover every possible corner-case. The rough tree of call types I came up with starts with the service specifier, and then what type of auth is used:

- DID service reference (eg, `did:web:api.bsky.app#bsky_appview`)
  - PDS proxying (requires `goat account login`)
  - direct inter-service auth (would require configured "iss" service DID, and secrete key for signing JWT)
- URL/hostname( eg, `https://api.bsky.app`)
  - unauthenticated (public HTTP APIs)
  - admin auth (eg, HTTP Basic with username `admin` and a password)
- PDS (`@pds`)
  - PDS account session (requires `goat account login`)

This PR supports all of these except for direct service auth, which I plan to add later.

Have some follow-up tasks in an issue: https://github.com/bluesky-social/goat/issues/45