### PR TITLE
pds admin: honor PDS_ENV_FILE to override /pds/pds.env lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - flag to resolve handles when listing PDS accounts
+- `PDS_ENV_FILE` env var to override the default `/pds/pds.env` lookup path used by `goat pds admin` for `PDS_ADMIN_PASSWORD`
 
 ### Changed
 

--- a/pds_admin.go
+++ b/pds_admin.go
@@ -174,8 +174,14 @@ var cmdPDSAdmin = &cli.Command{
 func NewPDSAdminClient(cmd *cli.Command) (*atclient.APIClient, error) {
 	adminPass := cmd.String("admin-password")
 	if adminPass == "" {
-		// try reading from PDS env file (if we are on PDS host or docker container)
-		b, err := os.ReadFile("/pds/pds.env")
+		// try reading from PDS env file (if we are on PDS host or docker container).
+		// PDS_ENV_FILE allows overriding the default /pds/pds.env path, useful for
+		// multi-tenant hosts or non-default install layouts.
+		envPath := os.Getenv("PDS_ENV_FILE")
+		if envPath == "" {
+			envPath = "/pds/pds.env"
+		}
+		b, err := os.ReadFile(envPath)
 		if err == nil {
 			scanner := bufio.NewScanner(strings.NewReader(string(b)))
 			for scanner.Scan() {


### PR DESCRIPTION
## Summary

When `PDS_ADMIN_PASSWORD` is not provided via the `--admin-password` flag or the `PDS_ADMIN_PASSWORD` / `ATP_AUTH_ADMIN_PASSWORD` env vars, `NewPDSAdminClient` falls back to reading `/pds/pds.env`. This hardcoded path is awkward for two cases:

1. **Multi-tenant hosts** running more than one PDS instance, each with its own env file under a different prefix (e.g. `/srv/pds-foo/pds.env`, `/srv/pds-bar/pds.env`).
2. **Non-default install layouts** where the operator chose a different data directory.

This PR adds a `PDS_ENV_FILE` env var that, when set, overrides the default lookup path. When the var is not set, the default behavior (read `/pds/pds.env`) is unchanged — so this is fully backwards-compatible.

## Why an env var rather than a flag

Symmetry with how `PDS_ADMIN_PASSWORD` itself is already discovered. Operators who run `goat pds admin` from scripts/cron/systemd units can set both via environment without changing the command line.

## Test

```bash
# With PDS_ENV_FILE pointing at a custom file:
$ PDS_ENV_FILE=/tmp/test-pds-env/pds.env goat pds admin --pds-host http://127.0.0.1:1 account list
error: Get "http://127.0.0.1:1/xrpc/com.atproto.sync.listRepos?...": dial tcp 127.0.0.1:1: connect: connection refused
# (auth was loaded from custom path; failed only on the API call)

# Without PDS_ENV_FILE on a host where /pds/pds.env does not exist:
$ goat pds admin --pds-host http://127.0.0.1:1 account list
error: PDS admin password required
# (unchanged from before)
```

## Notes

- CHANGELOG.md updated under UNRELEASED → Added.
- No changes to existing flags or env var sources.