### PR TITLE
Fix Windows-safe default export paths

### DIFF
--- a/blob.go
+++ b/blob.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	comatproto "github.com/bluesky-social/indigo/api/atproto"
 	"github.com/bluesky-social/indigo/atproto/atclient"
@@ -102,11 +103,13 @@ func runBlobExport(ctx context.Context, cmd *cli.Command) error {
 
 	topDir := cmd.String("output")
 	if topDir == "" {
-		topDir = fmt.Sprintf("%s_blobs", username)
+		topDir = fmt.Sprintf("%s_blobs", portableFilenameComponent(username))
 	}
 
 	fmt.Printf("downloading blobs to: %s\n", topDir)
-	os.MkdirAll(topDir, os.ModePerm)
+	if err := os.MkdirAll(topDir, os.ModePerm); err != nil {
+		return err
+	}
 
 	cursor := ""
 	for {
@@ -115,7 +118,7 @@ func runBlobExport(ctx context.Context, cmd *cli.Command) error {
 			return err
 		}
 		for _, cidStr := range resp.Cids {
-			blobPath := topDir + "/" + cidStr
+			blobPath := filepath.Join(topDir, cidStr)
 			if _, err := os.Stat(blobPath); err == nil {
 				fmt.Printf("%s\texists\n", blobPath)
 				continue

--- a/repo.go
+++ b/repo.go
@@ -119,7 +119,7 @@ func runRepoExport(ctx context.Context, cmd *cli.Command) error {
 	if carPath == "" {
 		// NOTE: having the rev in the the path might be nice
 		now := time.Now().Format("20060102150405")
-		carPath = fmt.Sprintf("%s.%s.car", username, now)
+		carPath = fmt.Sprintf("%s.%s.car", portableFilenameComponent(username), now)
 	}
 	output, err := getFileOrStdout(carPath)
 	if err != nil {

--- a/util.go
+++ b/util.go
@@ -63,6 +63,38 @@ func resolveToDID(ctx context.Context, cmd *cli.Command, s string) (syntax.DID, 
 
 const stdIOPath = "-"
 
+var portableFilenameReplacer = strings.NewReplacer(
+	"<", "_",
+	">", "_",
+	":", "_",
+	`"`, "_",
+	"/", "_",
+	`\`, "_",
+	"|", "_",
+	"?", "_",
+	"*", "_",
+)
+
+func portableFilenameComponent(name string) string {
+	name = portableFilenameReplacer.Replace(name)
+	name = strings.TrimRight(name, ". ")
+	if name == "" {
+		return "_"
+	}
+
+	base := name
+	if idx := strings.IndexRune(base, '.'); idx >= 0 {
+		base = base[:idx]
+	}
+	switch strings.ToUpper(base) {
+	case "CON", "PRN", "AUX", "NUL",
+		"COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9",
+		"LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9":
+		return "_" + name
+	}
+	return name
+}
+
 func getFileOrStdin(path string) (io.Reader, error) {
 	if path == stdIOPath {
 		return os.Stdin, nil

--- a/util_test.go
+++ b/util_test.go
@@ -1,0 +1,32 @@
+package main
+
+import "testing"
+
+func TestPortableFilenameComponentKeepsHandleReadable(t *testing.T) {
+	got := portableFilenameComponent("jay.bsky.team")
+	if got != "jay.bsky.team" {
+		t.Fatalf("expected handle to be unchanged, got %q", got)
+	}
+}
+
+func TestPortableFilenameComponentReplacesWindowsReservedCharacters(t *testing.T) {
+	got := portableFilenameComponent(`did:plc:abc<def>"ghi/jkl\mno|pqr?stu*vw`)
+	want := "did_plc_abc_def__ghi_jkl_mno_pqr_stu_vw"
+	if got != want {
+		t.Fatalf("expected %q, got %q", want, got)
+	}
+}
+
+func TestPortableFilenameComponentAvoidsWindowsReservedNames(t *testing.T) {
+	got := portableFilenameComponent("CON.car")
+	if got != "_CON.car" {
+		t.Fatalf("expected reserved name to be prefixed, got %q", got)
+	}
+}
+
+func TestPortableFilenameComponentHandlesEmptyAfterTrim(t *testing.T) {
+	got := portableFilenameComponent("...")
+	if got != "_" {
+		t.Fatalf("expected empty filename fallback, got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes generated default export paths so DID-based account identifiers work on Windows/NTFS.

- sanitize default output path components for `goat blob export` and `goat repo export`
- keep readable handle defaults unchanged, e.g. `jay.bsky.team_blobs`
- preserve explicit `--output` paths exactly as provided
- add regression coverage for Windows-reserved characters, reserved device names, and empty/trailing-dot cases

## Root cause

When users export by DID, goat generated paths like `did:plc:..._blobs` and `did:plc:....car`. The `:` character is invalid in NTFS filenames, so the export failed on Windows before migration data could be written.

Fixes #13.

## Validation

- `go test ./...`
- `git diff --check`